### PR TITLE
ci: publish to npm as dsh-auth-gate and fix release pipeline

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,7 @@ name: Release
 on:
   push:
     branches: [main]
+  workflow_dispatch:
 
 permissions:
   contents: write
@@ -13,6 +14,22 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: googleapis/release-please-action@v4
+        id: release
         with:
           release-type: node
           token: ${{ secrets.GITHUB_TOKEN }}
+
+  publish:
+    needs: release-please
+    if: ${{ needs.release-please.outputs.release_created }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v5
+        with:
+          node-version: 22
+          registry-url: https://registry.npmjs.org/
+      - run: npm ci --registry=https://registry.npmjs.org/
+      - run: npm publish --registry=https://registry.npmjs.org/
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -34,10 +34,10 @@ in first.
 ```sh
 # 1. Install the plugin (build a tarball, copy it to your server)
 npm pack
-scp dsh-auth-0.0.0.tgz your-server:/tmp/
+scp dsh-auth-gate-0.0.0.tgz your-server:/tmp/
 
 # 2. On the server, install it into your dsh profile
-dsh plugin --profile web add /tmp/dsh-auth-0.0.0.tgz
+dsh plugin --profile web add /tmp/dsh-auth-gate-0.0.0.tgz
 
 # 3. Create an admin account
 printf '%s\n' 'choose-a-strong-password' | dsh-auth user add admin --password-stdin
@@ -56,7 +56,7 @@ Edit `$DSH_HOME/cordis.patch.yml` (copy the shipped template from
 ```yaml
 - insert:
     - id: dsh-auth
-      name: dsh-auth
+      name: dsh-auth-gate
       config:
         mode: "password" # "password" (recommended) or "token"
         cookieSecure: true # keep true when you use https

--- a/README.md
+++ b/README.md
@@ -2,129 +2,91 @@
 
 **English** | [简体中文](README.zh.md)
 
-Application-layer authentication for the
-[DeepSeek Harness](https://github.com/deepseek-ai/dsh) web surface. It wraps
-the `webServer` route tables with a login gate, so a public dsh deployment is
-protected before any agent session, session history, or LLM credentials can be
-reached.
+A login door for your [DeepSeek Harness](https://github.com/deepseek-ai/dsh)
+(dsh) web instance. Put it in front of a public dsh deployment and nobody can
+reach your agents, your chat sessions, or your LLM credentials without signing
+in first.
 
-Ask your agent to deploy it, and it will: pack the package, install it into a
-dsh profile (`dsh plugin --profile web add <tarball>`), create the
-`users.yaml` credential file with the bundled CLI, wire the production
-overlay, and run the acceptance checklist against the live instance — see
-[docs/deployment.md](docs/deployment.md).
+## What it does
 
-## What it adds
+- **Everything needs a login.** Every page, API call, and WebSocket connection
+  is checked. Visitors without a valid session are sent to a simple login page
+  (or rejected with `401` for API/script requests).
+- **Two ways to sign in** (pick one in the configuration):
+  - **Password** (recommended): each admin gets a username and password.
+  - **Token**: one shared secret token for the whole instance.
+- **Works for browsers and scripts.** Browsers use the login page; scripts and
+  curl can pass `Authorization: Bearer <token>` and skip the page entirely.
+- **Safe by default.** Passwords are stored hashed, logins are rate-limited
+  (repeated wrong attempts temporarily lock the address), session cookies are
+  secure, and any missing or broken configuration **blocks access instead of
+  silently opening the door**.
+- **A small command-line tool** for managing users:
 
-**A guard over all four entry types** of `webServer` (exact routes, prefixes,
-fallback, WebSocket upgrades), with a boot-time self-check that fails loud if
-any entry is left unwrapped. Requests without a valid session are rejected:
-302 to the login page for browser navigation, 401 / refused handshake for
-API/WS. It is a single-door model: passing the gate means full access — there
-is no per-user isolation (see [docs/dsh-auth-plan.md](docs/dsh-auth-plan.md)).
+  ```sh
+  dsh-auth user add admin --password-stdin   # add a user
+  dsh-auth user list                          # list users
+  dsh-auth user disable admin                 # block a user's future logins
+  ```
 
-**Two mutually exclusive login flows** (choose one via `mode`):
-
-| Mode                    | Credential                                                                        | Bearer channel                                                      | Entry points                                                    |
-| ----------------------- | --------------------------------------------------------------------------------- | ------------------------------------------------------------------- | --------------------------------------------------------------- |
-| `"token"` (default, M2) | Shared random token from `$DSH_HOME/.credentials.yaml` (env ref `DSH_AUTH_TOKEN`) | `Authorization: Bearer <token>` (constant-time compare)             | `GET/POST /auth/login`, `POST /auth/logout`, `GET /auth/status` |
-| `"password"` (M3)       | Username/password from `$DSH_HOME/auth/users.yaml` (scrypt hashes)                | `Authorization: Bearer <session token>` (session lookup, revocable) | same four endpoints + `dsh-auth` CLI                            |
-
-**Security properties** (both modes):
-
-- `HttpOnly; Secure; SameSite=Lax` session cookies (`cookieSecure` off for
-  http test environments); session tokens stored as SHA-256 digests;
-  256-bit random issuance, new session per login (anti-fixation);
-- Password mode: scrypt (`node:crypto`, N=2¹⁶ / r=8 / p=1), constant-time
-  verification with a dummy-hash path for unknown users (no enumeration),
-  uniform 401 for unknown/wrong/disabled accounts, users file re-read per
-  login (no restart needed), 0600 permission discipline;
-- Login rate limiting: per-IP + per-account buckets, exponential backoff
-  (30 s base, 15 min cap), `429 + retry-after` while locked;
-- Fail-closed: missing credentials/users file, unparseable file, or missing
-  session store all deny rather than silently allow; the guard self-check
-  aborts startup if anything is unwrapped.
-
-**CLI** (`dsh-auth`, bin shipped with the package):
+## Quick start
 
 ```sh
-dsh-auth user add admin --password-stdin     # create a user, hash written to users.yaml
-dsh-auth user list                            # list users (disabled marked)
-dsh-auth user disable admin                   # block new logins (existing sessions stay valid)
-# all subcommands accept --file <path>
+# 1. Install the plugin (build a tarball, copy it to your server)
+npm pack
+scp dsh-auth-0.0.0.tgz your-server:/tmp/
+
+# 2. On the server, install it into your dsh profile
+dsh plugin --profile web add /tmp/dsh-auth-0.0.0.tgz
+
+# 3. Create an admin account
+printf '%s\n' 'choose-a-strong-password' | dsh-auth user add admin --password-stdin
+
+# 4. Turn on password login: add the dsh-auth row to $DSH_HOME/cordis.patch.yml
+#    (a ready-to-use template ships in deploy/cordis.patch.yml; see Configuration)
+
+# 5. Restart dsh. Open your site — you will be asked to sign in.
 ```
-
-## Example session
-
-A typical deployment flow (run by you or your agent):
-
-1. **Pack & install** — `npm pack` → `scp dsh-auth-*.tgz server:/tmp/` →
-   `dsh plugin --profile web add /tmp/dsh-auth-*.tgz` (forwards to pnpm).
-2. **Create an admin** — `printf '%s\n' '<strong-password>' | dsh-auth user add admin --password-stdin`.
-3. **Configure** — copy [deploy/cordis.patch.yml](deploy/cordis.patch.yml) to
-   `$DSH_HOME/cordis.patch.yml`; set `mode: "password"` and keep
-   `cookieSecure: true` behind TLS.
-4. **Verify** — restart, then run the acceptance sequence
-   ([docs/deployment.md](docs/deployment.md) §4): unauthenticated requests are
-   rejected, login issues a session cookie, the Bearer session token passes the
-   gate, WS upgrades need a cookie, logout revokes, and the rate limiter
-   returns `429 + retry-after` after repeated failures.
-
-## Requirements
-
-- Node ≥ 22.19 (same as the target dsh deployment); pnpm for `dsh plugin add`
-  (server npm global prefix may need `--prefix ~/.npm-global`);
-- A working dsh web profile; TLS termination in front for
-  `cookieSecure: true` (curl/scripts are unaffected by `Secure`);
-- `--trusted-host` is orthogonal: it guards against DNS rebinding, it is not
-  authentication — configure both on a public instance.
-
-## Install
-
-The package is not published to npm (UNLICENSED). Install from a tarball:
-
-```sh
-# on the source machine
-npm pack                                  # produces dsh-auth-<version>.tgz
-scp dsh-auth-<version>.tgz server:/tmp/
-
-# on the server
-dsh plugin --profile web add /tmp/dsh-auth-<version>.tgz
-```
-
-Upgrade by repacking and re-adding; remove with
-`dsh plugin --profile web remove dsh-auth` (and delete the overlay row).
 
 ## Configuration
 
-Plugin row config (in `$DSH_HOME/cordis.patch.yml`):
+Edit `$DSH_HOME/cordis.patch.yml` (copy the shipped template from
+`deploy/cordis.patch.yml`). The `dsh-auth` row:
 
-| Field          | Default            | Meaning                                                                      |
-| -------------- | ------------------ | ---------------------------------------------------------------------------- |
-| `mode`         | `"token"`          | `"token"` (M2 shared token) or `"password"` (M3)                             |
-| `sessionTtl`   | `604800`           | Session TTL in seconds, fixed expiry from creation                           |
-| `cookieName`   | `dsh_auth`         | Session cookie name                                                          |
-| `tokenRef`     | `"DSH_AUTH_TOKEN"` | Token mode: credentials reference (env var name)                             |
-| `cookieSecure` | `true`             | Add `; Secure`; keep `false` only for http test environments                 |
-| `usersFile`    | `""`               | Password mode: users.yaml path; `""` = `${DSH_HOME:-~/.dsh}/auth/users.yaml` |
+```yaml
+- insert:
+    - id: dsh-auth
+      name: dsh-auth
+      config:
+        mode: "password" # "password" (recommended) or "token"
+        cookieSecure: true # keep true when you use https
+```
 
-## Docs
+| Option         | Default            | What it does                                                                       |
+| -------------- | ------------------ | ---------------------------------------------------------------------------------- |
+| `mode`         | `"token"`          | `"password"` = username/password login; `"token"` = one shared secret              |
+| `sessionTtl`   | `604800`           | How long a login lasts (seconds) before you must sign in again                     |
+| `cookieName`   | `dsh_auth`         | Name of the session cookie (rarely needs changing)                                 |
+| `tokenRef`     | `"DSH_AUTH_TOKEN"` | Token mode only: which environment variable holds the shared secret                |
+| `cookieSecure` | `true`             | Set to `false` only if you are testing over plain http                             |
+| `usersFile`    | `""`               | Password mode: where your user list lives. Defaults to `$DSH_HOME/auth/users.yaml` |
 
-- Roadmap & threat model: [docs/dsh-auth-plan.md](docs/dsh-auth-plan.md)
-- Executable specs (authoritative for implementation):
-  [docs/impl-m1.md](docs/impl-m1.md) / [docs/impl-m2.md](docs/impl-m2.md) /
-  [docs/impl-m3.md](docs/impl-m3.md)
-- Deployment & acceptance checklist: [docs/deployment.md](docs/deployment.md)
-  - [deploy/cordis.patch.yml](deploy/cordis.patch.yml)
-- Development conventions: [docs/development.md](docs/development.md)
+## Requirements
 
-## Known limitations
+- Node ≥ 22.19 and pnpm on the server.
+- The dsh `web` profile running (`dsh --profile web`).
+- If `cookieSecure` is `true`, your site must be served over https (browsers
+  refuse secure cookies on plain http).
 
-- Disabling a user only blocks new logins; issued sessions stay valid until
-  their TTL (no `revokeBySubject` yet).
-- Rate limiting is in-memory (resets on restart) and keys on the socket peer
-  address — `X-Forwarded-For` is deliberately untrusted, so behind a reverse
-  proxy limits aggregate by the proxy's address.
-- No CSRF token on login (single-door model has no per-user isolation;
-  `SameSite=Lax` covers most cases; residual risk reassessed in M4).
-- No client-side GUI (logout button) yet.
+## Notes & limitations
+
+- Disabling a user only stops **new** logins; already-signed-in sessions stay
+  valid until they expire.
+- Login rate limiting resets when the server restarts.
+- Behind a reverse proxy, rate limiting counts by the proxy's address.
+- There is no logout button in the dsh interface yet — visit
+  `/auth/logout?next=/` to sign out.
+- The plugin only protects dsh's web surface. It is not a replacement for
+  server-level security: keep the server OS user locked down and the config
+  files private (`.credentials.yaml` and `auth/users.yaml` are created with
+  `0600` permissions).

--- a/README.zh.md
+++ b/README.zh.md
@@ -29,10 +29,10 @@
 ```sh
 # 1. 打包插件并复制到服务器
 npm pack
-scp dsh-auth-0.0.0.tgz your-server:/tmp/
+scp dsh-auth-gate-0.0.0.tgz your-server:/tmp/
 
 # 2. 在服务器上装进你的 dsh profile
-dsh plugin --profile web add /tmp/dsh-auth-0.0.0.tgz
+dsh plugin --profile web add /tmp/dsh-auth-gate-0.0.0.tgz
 
 # 3. 创建管理员账号
 printf '%s\n' '选一个强密码' | dsh-auth user add admin --password-stdin
@@ -51,7 +51,7 @@ printf '%s\n' '选一个强密码' | dsh-auth user add admin --password-stdin
 ```yaml
 - insert:
     - id: dsh-auth
-      name: dsh-auth
+      name: dsh-auth-gate
       config:
         mode: "password" # "password"（推荐）或 "token"
         cookieSecure: true # 使用 https 时保持 true

--- a/README.zh.md
+++ b/README.zh.md
@@ -2,109 +2,81 @@
 
 [English](README.md) | **简体中文**
 
-面向 [DeepSeek Harness](https://github.com/deepseek-ai/dsh) web 表面的应用层认证插件：包装
-`webServer` 路由表为登录门，公网部署的 dsh 实例在 agent 平面、会话库与 LLM 凭据可达之前
-先被认证门保护。
+给 [DeepSeek Harness](https://github.com/deepseek-ai/dsh)（dsh）网页版加一道登录门。部署到
+公网 dsh 实例前面之后，不登录就没人能碰到你的 agent、聊天会话和 LLM 凭证。
 
-让 agent 帮你部署：打包 → 装进 dsh profile（`dsh plugin --profile web add <tarball>`）→
-用随包 CLI 建 `users.yaml` 凭证 → 挂生产 overlay → 对活实例跑验收清单——
-见 [docs/deployment.md](docs/deployment.md)。
+## 它能做什么
 
-## 提供什么
+- **所有访问都要先登录。** 每个页面、每个 API 调用、每条 WebSocket 连接都会检查；
+  没有有效会话的访客会被带到简单的登录页（API/脚本请求则返回 `401`）。
+- **两种登录方式**（配置里二选一）：
+  - **密码**（推荐）：每个管理员一个用户名和密码。
+  - **令牌**：整个实例共用一个秘密令牌。
+- **浏览器和脚本都能用。** 浏览器走登录页；脚本和 curl 直接带
+  `Authorization: Bearer <token>` 就能跳过登录页。
+- **默认就安全。** 密码只存哈希、登录有限速（反复输错会临时锁定该地址）、会话 cookie
+  带安全属性，而且配置缺失或损坏时**拒绝访问而不是悄悄开门**。
+- **一个管理用户的小命令行工具**：
 
-**覆盖 `webServer` 四类入口的守卫**（exact 路由、前缀、fallback、WS 升级），启动自检
-fail loud（任何入口未包装即启动失败）。无有效会话的请求被拒绝：浏览器导航 302 到登录页、
-API/WS 401/拒握手。**单门模型**：过门 = 完整访问，无用户间隔离
-（见 [docs/dsh-auth-plan.md](docs/dsh-auth-plan.md)）。
+  ```sh
+  dsh-auth user add admin --password-stdin   # 添加用户
+  dsh-auth user list                          # 查看用户
+  dsh-auth user disable admin                 # 禁止某用户今后登录
+  ```
 
-**两种互斥登录流**（`mode` 二选一）：
-
-| 模式                  | 凭证                                                                        | Bearer 通道                                              | 入口                                                            |
-| --------------------- | --------------------------------------------------------------------------- | -------------------------------------------------------- | --------------------------------------------------------------- |
-| `"token"`（默认，M2） | `$DSH_HOME/.credentials.yaml` 的共享随机 token（env 引用 `DSH_AUTH_TOKEN`） | `Authorization: Bearer <token>`（恒时比较）              | `GET/POST /auth/login`、`POST /auth/logout`、`GET /auth/status` |
-| `"password"`（M3）    | `$DSH_HOME/auth/users.yaml` 的用户名/口令（scrypt 哈希）                    | `Authorization: Bearer <会话 token>`（会话查表，可吊销） | 同上四个端点 + `dsh-auth` CLI                                   |
-
-**安全特性**（两模式共有）：
-
-- `HttpOnly; Secure; SameSite=Lax` 会话 cookie（`cookieSecure` 可关，供 http 测试环境）；
-  会话 token 只存 SHA-256 摘要；256-bit 随机签发、每次登录新会话（防固定）；
-- password 模式：scrypt（`node:crypto`，N=2¹⁶ / r=8 / p=1）、恒时验证 + 未知用户占位哈希
-  路径（防枚举）、未知/错口令/禁用统一 401、users 文件每次登录现读（免重启）、0600 权限纪律；
-- 登录限速：IP + 账号双桶、指数退避（30s 起、15min 封顶）、锁定期 `429 + retry-after`；
-- fail-closed：凭证/users 文件缺失、文件不可解析、会话存储缺失一律拒绝而非静默放行；
-  守卫自检未全覆盖即中止启动。
-
-**CLI**（`dsh-auth`，随包 bin）：
+## 快速开始
 
 ```sh
-dsh-auth user add admin --password-stdin     # 建用户，哈希写入 users.yaml
-dsh-auth user list                            # 列出用户（禁用带标记）
-dsh-auth user disable admin                   # 禁用（只拦新登录；已发会话 TTL 内有效）
-# 所有子命令支持 --file <path>
+# 1. 打包插件并复制到服务器
+npm pack
+scp dsh-auth-0.0.0.tgz your-server:/tmp/
+
+# 2. 在服务器上装进你的 dsh profile
+dsh plugin --profile web add /tmp/dsh-auth-0.0.0.tgz
+
+# 3. 创建管理员账号
+printf '%s\n' '选一个强密码' | dsh-auth user add admin --password-stdin
+
+# 4. 开启密码登录：在 $DSH_HOME/cordis.patch.yml 里加 dsh-auth 行
+#    （仓库自带现成模板 deploy/cordis.patch.yml，见下方"配置"）
+
+# 5. 重启 dsh，打开你的站点——会先要求登录。
 ```
-
-## 示例流程
-
-典型部署流程（你或你的 agent 执行）：
-
-1. **打包安装** — `npm pack` → `scp dsh-auth-*.tgz server:/tmp/` →
-   `dsh plugin --profile web add /tmp/dsh-auth-*.tgz`（转发 pnpm）。
-2. **建管理员** — `printf '%s\n' '<强口令>' | dsh-auth user add admin --password-stdin`。
-3. **配置** — 把 [deploy/cordis.patch.yml](deploy/cordis.patch.yml) 复制为
-   `$DSH_HOME/cordis.patch.yml`；设 `mode: "password"`，TLS 环境保持 `cookieSecure: true`。
-4. **验收** — 重启后跑 [docs/deployment.md](docs/deployment.md) §4 序列：未认证请求被拒、
-   登录发会话 cookie、Bearer 会话 token 过门、WS 升级需 cookie、登出吊销、连续失败后
-   限速返回 `429 + retry-after`。
-
-## 前置条件
-
-- Node ≥ 22.19（与目标 dsh 部署一致）；`dsh plugin add` 需要 pnpm（服务器 npm 全局 prefix
-  可能需要 `--prefix ~/.npm-global`）；
-- 可用的 dsh web profile；`cookieSecure: true` 需前置 TLS 终结（curl/脚本不受 `Secure` 影响）；
-- `--trusted-host` 与认证**正交**：它只是 DNS-rebinding 防栏，不是认证——公网实例两者都要配。
-
-## 安装
-
-包未发布 npm（UNLICENSED），从 tarball 安装：
-
-```sh
-# 源机器
-npm pack                                  # 产出 dsh-auth-<version>.tgz
-scp dsh-auth-<version>.tgz server:/tmp/
-
-# 服务器
-dsh plugin --profile web add /tmp/dsh-auth-<version>.tgz
-```
-
-升级：重新打包再 add；卸载：`dsh plugin --profile web remove dsh-auth`（并删 overlay 行）。
 
 ## 配置
 
-插件行 config（`$DSH_HOME/cordis.patch.yml`）：
+编辑 `$DSH_HOME/cordis.patch.yml`（复制仓库里的模板 `deploy/cordis.patch.yml`），
+`dsh-auth` 行：
 
-| 字段           | 默认               | 说明                                                                         |
-| -------------- | ------------------ | ---------------------------------------------------------------------------- |
-| `mode`         | `"token"`          | `"token"`（M2 共享 token）或 `"password"`（M3）                              |
-| `sessionTtl`   | `604800`           | 会话 TTL（秒），自创建起固定过期                                             |
-| `cookieName`   | `dsh_auth`         | 会话 cookie 名                                                               |
-| `tokenRef`     | `"DSH_AUTH_TOKEN"` | token 模式：credentials 引用名（环境变量名）                                 |
-| `cookieSecure` | `true`             | 加 `; Secure`；仅 http 测试环境关                                            |
-| `usersFile`    | `""`               | password 模式：users.yaml 路径；`""` = `${DSH_HOME:-~/.dsh}/auth/users.yaml` |
+```yaml
+- insert:
+    - id: dsh-auth
+      name: dsh-auth
+      config:
+        mode: "password" # "password"（推荐）或 "token"
+        cookieSecure: true # 使用 https 时保持 true
+```
 
-## 文档
+| 选项           | 默认值             | 作用                                                         |
+| -------------- | ------------------ | ------------------------------------------------------------ |
+| `mode`         | `"token"`          | `"password"` = 用户名密码登录；`"token"` = 一个共享秘密      |
+| `sessionTtl`   | `604800`           | 一次登录持续多久（秒），到期需重新登录                       |
+| `cookieName`   | `dsh_auth`         | 会话 cookie 的名字（很少需要改）                             |
+| `tokenRef`     | `"DSH_AUTH_TOKEN"` | 仅令牌模式：共享秘密存在哪个环境变量里                       |
+| `cookieSecure` | `true`             | 只在纯 http 测试环境设为 `false`                             |
+| `usersFile`    | `""`               | 密码模式：用户列表文件位置。默认 `$DSH_HOME/auth/users.yaml` |
 
-- 路线图与威胁模型：[docs/dsh-auth-plan.md](docs/dsh-auth-plan.md)
-- 实施规格（实施唯一权威）：
-  [docs/impl-m1.md](docs/impl-m1.md) / [docs/impl-m2.md](docs/impl-m2.md) /
-  [docs/impl-m3.md](docs/impl-m3.md)
-- 部署与验收清单：[docs/deployment.md](docs/deployment.md) +
-  [deploy/cordis.patch.yml](deploy/cordis.patch.yml)
-- 开发规范：[docs/development.md](docs/development.md)
+## 环境要求
 
-## 已知局限
+- 服务器上需要 Node ≥ 22.19 和 pnpm。
+- dsh 的 `web` profile 正常运行（`dsh --profile web`）。
+- 如果 `cookieSecure` 是 `true`，站点必须走 https（浏览器在纯 http 下会拒绝安全 cookie）。
 
-- 禁用用户只拦新登录；已发会话在 TTL 内有效（暂无 `revokeBySubject`）。
-- 限速内存态（重启清零），按键为 socket 直连地址——故意不信任 `X-Forwarded-For`，反代部署
-  时限速按反代出口 IP 聚合。
-- 登录无 CSRF token（单门模型无用户间隔离；`SameSite=Lax` 已覆盖大部分；残余风险 M4 再评估）。
-- 暂无 client 半边 GUI（登出按钮）。
+## 注意事项与局限
+
+- 禁用用户只阻止**新**登录；已经登录的会话要等它自然过期。
+- 登录限速在服务器重启后清零。
+- 反代部署时，限速按反代出口地址统计。
+- dsh 界面里还没有登出按钮——访问 `/auth/logout?next=/` 即可登出。
+- 本插件只保护 dsh 的网页入口，不能替代服务器层面的安全：请保持服务器系统用户最小权限、
+  配置文件私密（`.credentials.yaml` 和 `auth/users.yaml` 创建时即为 `0600` 权限）。

--- a/deploy/cordis.patch.yml
+++ b/deploy/cordis.patch.yml
@@ -12,7 +12,7 @@
 #   纪律：验收清单含"auth 行健康"检查）。
 - insert:
     - id: dsh-auth
-      name: dsh-auth
+      name: dsh-auth-gate
       config:
         mode: "password"
         cookieSecure: true

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -38,10 +38,10 @@ export PATH="$HOME/.npm-global/bin:$PATH"
 dsh plugin --profile web add /tmp/dsh-auth-<version>.tgz   # --profile 在 plugin 之后（实测）
 ```
 
-- 安装后 `$DSH_HOME/profiles/web/package.json` 的 `dependencies` 含 `dsh-auth`；
+- 安装后 `$DSH_HOME/profiles/web/package.json` 的 `dependencies` 含 `dsh-auth-gate`；
   `dsh plugin` 转发 pnpm，依赖（`yaml`、`@deepseek-ai/*`）自动从公共 npm 解析。
 - 升级：重新 `npm pack` + `dsh plugin --profile web add <新 tarball>`（pnpm 覆盖升级）。
-- 卸载：`dsh plugin --profile web remove dsh-auth`（同时删 overlay 行）。
+- 卸载：`dsh plugin --profile web remove dsh-auth-gate`（同时删 overlay 行）。
 
 ## 2. 配置
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "dsh-auth",
+  "name": "dsh-auth-gate",
   "version": "0.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "dsh-auth",
+      "name": "dsh-auth-gate",
       "version": "0.0.0",
       "license": "UNLICENSED",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "dsh-auth",
+  "name": "dsh-auth-gate",
   "version": "0.0.0",
   "description": "Application-layer authentication plugin for the dsh web surface",
   "type": "module",


### PR DESCRIPTION
## Fixes the release pipeline and publishes to npm

### Problem
- The Release workflow failed: GitHub Actions was not permitted to create pull
  requests, so release-please could not open the release PR (no tag, no release).
- No npm publish step existed; the `dsh-auth` name on npm belongs to another
  project (`github.com/hxy91819/dsh-auth`), so the package is published under a
  new name.

### Changes
- **Rename package to `dsh-auth-gate`** (`package.json`, `deploy/cordis.patch.yml`,
  README en/zh, `docs/deployment.md`, lockfile). The plugin row `id` stays
  `dsh-auth`; the `dsh-auth` CLI bin name is unchanged.
- **`release.yml`**: add `workflow_dispatch` for manual triggering, and an
  `npm publish` job that runs when release-please creates a release
  (`NODE_AUTH_TOKEN` = `NPM_TOKEN` secret, scoped to registry.npmjs.org).
- README install instructions now use the new tarball name.

### Next steps after merge
- Manually trigger the Release workflow (or wait for the next `main` push).
- Release-please opens a release PR (0.1.0) → merge it → tag + GitHub Release +
  `npm publish` to `dsh-auth-gate` (requires `NPM_TOKEN`, already configured).
