### PR TITLE
fix(ci): pass release_created through job outputs so publish can run

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,8 @@ permissions:
 jobs:
   release-please:
     runs-on: ubuntu-latest
+    outputs:
+      release_created: ${{ steps.release.outputs.release_created }}
     steps:
       - uses: googleapis/release-please-action@v4
         id: release


### PR DESCRIPTION
## Summary

The `publish` job gates on `needs.release-please.outputs.release_created`, but the `release-please` job never declared an `outputs:` block — GitHub Actions job outputs are empty unless declared, so `release_created` was always falsy and **`npm publish` has never run from the workflow** (previous publishes were manual).

This adds the missing outputs passthrough:

```yaml
  release-please:
    outputs:
      release_created: ${{ steps.release.outputs.release_created }}
```

Verified failure: after merging release PR #10 (0.1.1), the Release run created the tag + GitHub Release but the publish job was skipped (`- publish in 0s`), and npm still shows only 0.1.0/1.0.0.

Merging this PR triggers release-please → 0.1.2 release PR → merging that publishes 0.1.2 to npm through the fixed pipeline.