### PR TITLE
chore: remove stale bootstrap text from CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,11 +8,3 @@
 * implement M1 auth guard and persistent session store ([168b41e](https://github.com/TecFancy/dsh-auth/commit/168b41e145a9a737c48cf064530ad89ba88d23ba))
 * **m2:** shared token gate with login page and bearer auth ([aee37b4](https://github.com/TecFancy/dsh-auth/commit/aee37b46162c446a2aa808294aa0c854f8ac23e3))
 * **m3:** password login flow with scrypt users file rate limit and CLI ([db21eac](https://github.com/TecFancy/dsh-auth/commit/db21eac9ac30d5a2c1162b26d51597ac46db441d))
-
-## Changelog
-
-All notable changes to this project will be documented in this file.
-
-This file is generated and maintained by
-[release-please](https://github.com/googleapis/release-please) from conventional
-commits on `main`.


### PR DESCRIPTION
Removes the leftover `## Changelog / All notable changes...` bootstrap block at the bottom of CHANGELOG.md (residue of the hand version re-align in #6). Release-please only rewrites the top of the file, so this junk would otherwise persist forever. No release triggers (chore:).