### PR TITLE
feat(package): add npm keywords for discoverability

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,18 @@
   "description": "Application-layer authentication plugin for the dsh web surface",
   "type": "module",
   "license": "MIT",
+  "keywords": [
+    "dsh",
+    "dsh-plugin",
+    "auth",
+    "authentication",
+    "login",
+    "password",
+    "token",
+    "security",
+    "access-control",
+    "rate-limiting"
+  ],
   "engines": {
     "node": ">=22.19.0"
   },


### PR DESCRIPTION
Adds npm keywords to package.json (mirroring the dsh-deeptutor style: dsh ecosystem prefix + functional terms) so the package is discoverable on npmjs.com:

`dsh, dsh-plugin, auth, authentication, login, password, token, security, access-control, rate-limiting`

Note: keywords only take effect on publish — merging this triggers release-please → 0.3.0 release PR; merging that publishes to npm.