### PR TITLE
docs: bilingual documentation (English translations, _zh naming)

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,8 @@ Edit `$DSH_HOME/cordis.patch.yml` (copy the shipped template from
   and why auth alone doesn't fix them), and the recommended semi-shell
   topology.
 - [`docs/deployment.md`](docs/deployment.md) — ops checklist, acceptance steps
-  (A–I) and troubleshooting (Chinese).
+  (A–I) and troubleshooting. Chinese version:
+  [`docs/deployment_zh.md`](docs/deployment_zh.md).
 
 ## Requirements
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -74,9 +74,9 @@ printf '%s\n' '选一个强密码' | dsh-auth user add admin --password-stdin
 
 ## 部署
 
-- [反代部署指南](docs/reverse-proxy.zh.md) —— Caddy/nginx 配置、浏览器信任栅栏的坑
+- [反代部署指南](docs/reverse-proxy_zh.md) —— Caddy/nginx 配置、浏览器信任栅栏的坑
   （反代后设置页 `403`，以及为什么只加认证修不了它）、推荐的半外壳拓扑。
-- [docs/deployment.md](docs/deployment.md) —— 运维清单、验收步骤（A–I）与故障诊断。
+- [docs/deployment_zh.md](docs/deployment_zh.md) —— 运维清单、验收步骤（A–I）与故障诊断。
 
 ## 环境要求
 

--- a/deploy/cordis.patch.yml
+++ b/deploy/cordis.patch.yml
@@ -1,6 +1,6 @@
 # 生产 overlay 模板（dsh-auth-gate）
 #
-# 用法：复制到 $DSH_HOME/cordis.patch.yml 并按部署环境调整（见 docs/deployment.md）。
+# 用法：复制到 $DSH_HOME/cordis.patch.yml 并按部署环境调整（见 docs/deployment_zh.md）。
 # 前置条件：dsh-auth-gate 已安装到 profile（dsh plugin --profile web add <tarball>），
 #           $DSH_HOME/auth/users.yaml 已用 `dsh-auth user add` 建好（chmod 600）。
 #

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -1,196 +1,224 @@
-# dsh-auth-gate 部署与验收清单
+# dsh-auth-gate Deployment and Acceptance Checklist
 
-本文档描述如何把 dsh-auth-gate（password 模式，M3）部署到一个公网 dsh web 实例，并完成
-**部署验收**。适用于：实例已跑通 dsh web（`dsh --profile web`），需要加认证门。
+This document describes how to deploy dsh-auth-gate (password mode, M3) to a public dsh web
+instance and complete **deployment acceptance**. Applies to: an instance already running dsh
+web (`dsh --profile web`) that needs an authentication gate.
 
-设计依据：`docs/dsh-auth-plan.md` §7/§8（无上游 PR 通道的限制、纵深防御）；
-规格：`docs/impl-m2.md`（token 模式）、`docs/impl-m3.md`（password 模式）。
-**两个模式二选一**：下面按 password 模式（推荐，M3）编写；token 模式只需跳过
-"建用户"一步并配置 `tokenRef`。
-
----
-
-## 0. 前置条件
-
-- **TLS 前置终结**（Nginx/Caddy 反代或 LB）：`cookieSecure: true` 依赖 https，否则浏览器
-  不保存会话 cookie（curl/脚本不受影响）。http-only 环境只能 `cookieSecure: false`（仅测试）。
-- **`--trusted-host` 与认证正交**：`--trusted-host` 只是 DNS-rebinding 防栏，不是认证；
-  两者都需配置。公网实例：`--trusted-host <域名>` 指到你的域名。
-- **低权限 OS 用户**运行 dsh（无 sudo、无其他项目文件）——plan §8 纵深防御第 1 条。
-- **服务器有 Node ≥ 22.19**（与部署一致）与 pnpm（`dsh plugin` 转发 pnpm）。实测：npm 默认
-  global prefix 是 `/usr`（无 root 权限装不了），用
-  `npm i -g pnpm --prefix ~/.npm-global` 并 `export PATH="$HOME/.npm-global/bin:$PATH"`
-  （`dsh` 本身也装在这个 prefix，见 `docs/handoff-m2.md` §3.2）。
+Design basis: `docs/dsh-auth-plan.md` §7/§8 (absence of an upstream PR channel, defense in
+depth); specifications: `docs/impl-m2.md` (token mode), `docs/impl-m3.md` (password mode).
+**Choose one of the two modes**: the text below is written for password mode (recommended, M3);
+token mode only needs to skip the "create users" step and configure `tokenRef`.
 
 ---
 
-## 1. 安装 dsh-auth-gate（一次性）
+## 0. Prerequisites
 
-包已发布到 npm（`dsh-auth-gate`），一条命令装进目标 profile：
+- **TLS front termination** (Nginx/Caddy reverse proxy or LB): `cookieSecure: true` depends on
+  https, otherwise the browser does not save the session cookie (curl/scripts are unaffected).
+  An http-only environment can only use `cookieSecure: false` (testing only).
+- **`--trusted-host` and authentication are orthogonal**: `--trusted-host` is merely a
+  DNS-rebinding guard, not authentication; both need to be configured. Public instance:
+  `--trusted-host <domain>` points to your domain.
+- Run dsh under a **low-privilege OS user** (no sudo, no other project files) — plan §8,
+  defense-in-depth item 1.
+- The **server has Node ≥ 22.19** (consistent with deployment) and pnpm (`dsh plugin` forwards
+  to pnpm). Verified: npm's default global prefix is `/usr` (cannot install without root
+  privileges); use
+  `npm i -g pnpm --prefix ~/.npm-global` and `export PATH="$HOME/.npm-global/bin:$PATH"`
+  (`dsh` itself is also installed in this prefix, see `docs/handoff-m2.md` §3.2).
+
+---
+
+## 1. Install dsh-auth-gate (one-time)
+
+The package is published to npm (`dsh-auth-gate`); one command installs it into the target
+profile:
 
 ```bash
-# 服务器（$DSH_HOME 指向目标实例，如 ~/.dsh 或隔离目录）：
+# Server ($DSH_HOME points at the target instance, e.g. ~/.dsh or an isolated directory):
 export PATH="$HOME/.npm-global/bin:$PATH"
-dsh plugin --profile web add dsh-auth-gate   # 转发 pnpm，从公共 npm 解析（实测）
+dsh plugin --profile web add dsh-auth-gate   # forwards to pnpm, resolved from public npm (verified)
 ```
 
-- 安装后 `$DSH_HOME/profiles/web/package.json` 的 `dependencies` 含 `dsh-auth-gate`；
-  依赖（`yaml`、`@deepseek-ai/*`）自动从公共 npm 解析。
-- 升级：重跑同一命令（pnpm 拉新版本）。
-- 卸载：`dsh plugin --profile web remove dsh-auth-gate`（同时删 overlay 行）。
+- After installation, the `dependencies` of `$DSH_HOME/profiles/web/package.json` include
+  `dsh-auth-gate`; dependencies (`yaml`, `@deepseek-ai/*`) are resolved automatically from public
+  npm.
+- Upgrade: re-run the same command (pnpm pulls the new version).
+- Uninstall: `dsh plugin --profile web remove dsh-auth-gate` (also removes the overlay line).
 
-## 2. 配置
+## 2. Configuration
 
-1. **建管理员**（`users.yaml` 自动创建于 `$DSH_HOME/auth/users.yaml`，0600）：
+1. **Create the administrator** (`users.yaml` is auto-created at
+   `$DSH_HOME/auth/users.yaml`, 0600):
    ```bash
-   printf '%s\n' '<强口令>' | dsh-auth user add admin --password-stdin
-   dsh-auth user list                    # 确认
+   printf '%s\n' '<strong password>' | dsh-auth user add admin --password-stdin
+   dsh-auth user list                    # confirm
    ```
-   多管理员：重复 `user add`；禁用：`dsh-auth user disable <name>`。
-2. **overlay**：把仓库 `deploy/cordis.patch.yml` 复制为 `$DSH_HOME/cordis.patch.yml`，
-   按需调整（`cookieSecure` 必须与 TLS 环境一致；非默认路径才设 `usersFile`）。
-3. 确认无其他行占用 `dsh-auth-gate` id（patch 栈按 id 覆盖）。
+   Multiple administrators: repeat `user add`; disable: `dsh-auth user disable <name>`.
+2. **Overlay**: copy the repo's `deploy/cordis.patch.yml` to
+   `$DSH_HOME/cordis.patch.yml`, adjust as needed (`cookieSecure` must match the TLS
+   environment; only set `usersFile` for a non-default path).
+3. Confirm no other line occupies the `dsh-auth-gate` id (the patch stack overrides by id).
 
-## 3. 启动与健康检查
+## 3. Startup and Health Check
 
 ```bash
 cd "$DSH_HOME" && DSH_HOME="$DSH_HOME" setsid dsh --profile web --port 3081 \
-  > ~/dsh.log 2>&1 < /dev/null &                         # 等 ~25s
-tail -f ~/dsh.log                                        # 期望：无 error
+  > ~/dsh.log 2>&1 < /dev/null &                         # wait ~25s
+tail -f ~/dsh.log                                        # expected: no errors
 ```
 
-（实测：SSH 会话里 `nohup ... &` 可能因子进程持有 fd 让 ssh 挂起 2 分钟——**挂起不代表失败**，
-`setsid` 可立即返回；启动后另开连接检查 `pgrep` 与端口。停止：
-`pkill -f "[d]sh --profile web"`——括号技巧防自杀，kill 与启动分两个连接。）
+(Verified: in an SSH session, `nohup ... &` may hang ssh for 2 minutes because a child process
+holds the fd — **a hang does not mean failure**; `setsid` returns immediately; after startup,
+open another connection to check `pgrep` and the port. To stop:
+`pkill -f "[d]sh --profile web"` — the bracket trick prevents self-kill; kill and startup are in
+two separate connections.)
 
-启动自检（M1）：四类入口未全覆盖会 **fail loud**（进程启动失败并报
-`guard self-check failed`）——启动成功即守卫在位。日志应出现
-`session domain opened: dsh_auth_sessions`；无 `user store unavailable` /
-`users file not found`（首次登录前该 warn 正常——文件缺失=空用户集，fail-closed）。
+Startup self-check (M1): if the four categories of entry points are not fully covered, it
+**fails loud** (process startup fails and reports
+`guard self-check failed`) — successful startup means the guard is in place. The log should show
+`session domain opened: dsh_auth_sessions`; no `user store unavailable` /
+`users file not found` (that warn is normal before first login — a missing file = empty user set,
+fail-closed).
 
-## 4. 验收清单（部署后逐项执行）
+## 4. Acceptance Checklist (run each item after deployment)
 
-服务器本机（或经 SSH 隧道）执行。`jar` 是 curl cookie jar；`<TOKEN>` 是登录响应
-`set-cookie` 里的 `dsh_auth` 值（43 字符）。
+Run on the server itself (or via SSH tunnel). `jar` is a curl cookie jar; `<TOKEN>` is the
+`dsh_auth` value from the `set-cookie` in the login response (43 characters).
 
 ```bash
-# A. 登录页与守卫
+# A. Login page and the guard
 curl -s -o /dev/null -w "%{http_code}\n" http://127.0.0.1:3081/auth/login          # 200
-curl -s http://127.0.0.1:3081/auth/login | grep -o 'name="username"'                # 命中
+curl -s http://127.0.0.1:3081/auth/login | grep -o 'name="username"'                # hit
 
-# B. 未认证拒绝（导航 302 / API 401）
+# B. Unauthenticated rejection (navigation 302 / API 401)
 curl -s -o /dev/null -w "%{http_code}\n" -H "Accept: text/html" http://127.0.0.1:3081/__dsh_api  # 302
 curl -s -o /dev/null -w "%{http_code}\n" -H "Accept: application/json" http://127.0.0.1:3081/__dsh_api  # 401
 
-# C. 登录（错 → 401；对 → 302 + set-cookie）
+# C. Login (wrong → 401; correct → 302 + set-cookie)
 curl -s -o /dev/null -w "%{http_code}\n" -d "username=admin&password=wrong" http://127.0.0.1:3081/auth/login  # 401
-curl -s -i -d "username=admin&password=<口令>" -c jar http://127.0.0.1:3081/auth/login | head -3  # 302 + set-cookie
+curl -s -i -d "username=admin&password=<password>" -c jar http://127.0.0.1:3081/auth/login | head -3  # 302 + set-cookie
 
-# D. 会话 cookie 与 Bearer 会话 token
+# D. Session cookie and Bearer session token
 curl -s -o /dev/null -w "%{http_code}\n" -b jar http://127.0.0.1:3081/__dsh_api      # 200
 curl -s -b jar http://127.0.0.1:3081/auth/status                                     # {"authenticated":true}
 curl -s -o /dev/null -w "%{http_code}\n" -H "Authorization: Bearer <TOKEN>" http://127.0.0.1:3081/__dsh_api  # 200
 
-# E. 路由纪律（/auth 兜底不落 SPA fallback；method 纪律）
+# E. Route discipline (/auth falls through without hitting the SPA fallback; method discipline)
 curl -s -o /dev/null -w "%{http_code}\n" http://127.0.0.1:3081/auth/whatever         # 404
 curl -s -o /dev/null -w "%{http_code}\n" -X DELETE http://127.0.0.1:3081/auth/login  # 405
 
-# F. WS 升级通道（首行状态即可；--max-time 超时退出正常）
+# F. WS upgrade channel (first-line status is enough; timing out via --max-time is normal)
 curl --http1.1 -s -i --max-time 2 -b jar -H "Connection: Upgrade" -H "Upgrade: websocket" \
   -H "Sec-WebSocket-Key: $(openssl rand -base64 16)" -H "Sec-WebSocket-Version: 13" \
   http://127.0.0.1:3081/api/events.host | head -1                                    # 101
-# 无 cookie 变体 → 首行 401
+# no-cookie variant → first line 401
 
-# G. 登出与吊销
+# G. Logout and revocation
 curl -s -i -X POST "http://127.0.0.1:3081/auth/logout?next=/" -b jar | head -3        # 302 + Max-Age=0
 curl -s -o /dev/null -w "%{http_code}\n" -b jar http://127.0.0.1:3081/__dsh_api      # 401
 
-# H. 限速（放在最后——锁定 30s 起）
+# H. Rate limiting (run last — locks for 30s onward)
 for i in 1 2 3 4 5 6; do curl -s -o /dev/null -w "%{http_code}\n" -d "username=admin&password=wrong" \
-  http://127.0.0.1:3081/auth/login; done       # 第 1~N 次 401，锁定后 429（IP 桶会累计此前失败）
-curl -s -i -d "username=admin&password=<口令>" http://127.0.0.1:3081/auth/login | head -3  # 429 + retry-after
+  http://127.0.0.1:3081/auth/login; done       # first ~N times 401, after lock 429 (IP bucket accumulates prior failures)
+curl -s -i -d "username=admin&password=<password>" http://127.0.0.1:3081/auth/login | head -3  # 429 + retry-after
 
-# I. 浏览器通路（可选，须 https 环境）：无痕窗口访问 → 302 到 /auth/login →
-#    登录 → 进入实例；登出按钮未实现，URL 访问 /auth/logout?next=/ 登出。
+# I. Browser path (optional, requires an https environment): incognito window → visit → 302 to /auth/login →
+#    login → enter the instance; the logout button is not implemented, visit /auth/logout?next=/ via URL to log out.
 ```
 
-预期全绿 = 部署验收通过。**全部失败路径必须是失败**（401/403 语义不吞错）——任何"静默放行"
-（未认证拿到 200/101）都是部署错误。实测注：`cookieSecure: true` 只影响浏览器（curl 的
-cookie jar 不检查 `Secure`，验收序列照常）；H 组的锁定次数会累计此前步骤的失败（如 C 的
-`wrong` 一次）——以 `429 + retry-after` 出现为准。
+All green = deployment acceptance passes. **Every failure path must fail** (401/403 semantics,
+never swallow errors) — any "silent pass-through" (unauthenticated returning 200/101) is a
+deployment error. Verified note: `cookieSecure: true` only affects browsers (curl's cookie jar
+does not check `Secure`, so the acceptance sequence runs the same); the lock count in group H
+accumulates prior failures from earlier steps (e.g. the `wrong` attempt in C) — look for the
+`429 + retry-after` to appear.
 
-## 5. 升级与回归（dsh 升级必做）
+## 5. Upgrade and Regression (mandatory after every dsh upgrade)
 
-守卫包装依赖 `webServer` 非契约内部结构（plan §7）——**每次 dsh 升级后**：
+The guard wrapper depends on `webServer`'s non-contractual internal structures (plan §7)
+— **after each dsh upgrade**:
 
-1. 启动（§3）——自检 fail loud 即失败；
-2. 跑验收清单 B/D/F 三组（守卫 + 会话 + WS）；
-3. 检查 `boot.log` 无新增 error/warn。
+1. Start up (§3) — a fail-loud self-check means failure;
+2. Run acceptance groups B/D/F of the checklist (guard + session + WS);
+3. Check `boot.log` for any new error/warn.
 
-## 6. 故障诊断
+## 6. Troubleshooting
 
-| 症状                               | 原因                                              | 处理                                              |
-| ---------------------------------- | ------------------------------------------------- | ------------------------------------------------- |
-| 启动失败 `guard self-check failed` | 包装未覆盖全部入口（dsh 版本变化）                | 升级 dsh-auth-gate 或报告（勿绕过自检）           |
-| 登录恒 401                         | 口令错误 / 用户禁用 / users.yaml 缺失（空用户集） | `dsh-auth user list`；确认 `$DSH_HOME` 与实例一致 |
-| 登录 503 `user store unavailable`  | users.yaml 语法/schema 错、权限过宽（非 600）     | `chmod 600`；`dsh-auth user list` 复现错误信息    |
-| 登录 429                           | 限速锁定（内存态，重启清零）                      | 等 `retry-after` 或重启实例                       |
-| 浏览器登录后仍被拒                 | `cookieSecure: true` 但无 https                   | 补 TLS 前置，或临时 false（仅测试）               |
-| 认证后 API 仍 401                  | 反代没透传 cookie/Authorization                   | 检查反代 header 透传配置                          |
+| Symptom                                   | Cause                                                                | Handling                                                         |
+| ----------------------------------------- | -------------------------------------------------------------------- | ---------------------------------------------------------------- |
+| Startup failure `guard self-check failed` | Wrapper does not cover all entry points (dsh version changed)        | Upgrade dsh-auth-gate or report (do not bypass the self-check)   |
+| Login always 401                          | Wrong password / user disabled / users.yaml missing (empty user set) | `dsh-auth user list`; confirm `$DSH_HOME` matches the instance   |
+| Login 503 `user store unavailable`        | users.yaml syntax/schema error, permissions too loose (not 600)      | `chmod 600`; `dsh-auth user list` to reproduce the error message |
+| Login 429                                 | Rate-limit lock (in-memory state, cleared on restart)                | Wait for `retry-after` or restart the instance                   |
+| Rejected after browser login              | `cookieSecure: true` but no https                                    | Add TLS front termination, or temporarily false (testing only)   |
+| API still 401 after authentication        | Reverse proxy does not forward cookie/Authorization                  | Check the reverse proxy's header pass-through config             |
 
-## 7. 安全注意事项（plan §8 落地清单）
+## 7. Security Notes (plan §8 concrete checklist)
 
-- [ ] `$DSH_HOME/.credentials.yaml` 与 `auth/users.yaml` 均 `chmod 600`（dsh-auth CLI 自动 600）。
-- [ ] 会话日志视同含密材料（备份/共享同等防护）。
-- [ ] 升级回归（§5）纳入运维流程；auth 行健康检查（`boot.log` + 验收 B/D/F）纳入监控。
-- [ ] 口令哈希为 scrypt（`docs/impl-m3.md` P1）；文件零明文。
-- [ ] 禁用用户只拦新登录（已发会话 TTL 内有效，M3 已知局限）。
-- [ ] 限速内存态重启清零；反代部署时限速按出口 IP 聚合（不信任 X-Forwarded-For）。
+- [ ] Both `$DSH_HOME/.credentials.yaml` and `auth/users.yaml` are `chmod 600` (dsh-auth CLI
+      auto-sets 600).
+- [ ] Treat session logs as confidential material (protect backups/sharing equally).
+- [ ] Fold upgrade regression (§5) into the ops process; add auth-line health checks
+      (`boot.log` + acceptance B/D/F) to monitoring.
+- [ ] Password hashes are scrypt (`docs/impl-m3.md` P1); the file has zero plaintext.
+- [ ] A disabled user only blocks new logins (issued sessions remain valid within TTL, a known
+      M3 limitation).
+- [ ] Rate limiting is in-memory and cleared on restart; in a reverse-proxy deployment, rate
+      limiting aggregates by egress IP (do not trust X-Forwarded-For).
 
-## 8. 公网部署变体（2026-08-15 起，dsh.hi-ruofei.com 生效）：半外壳
+## 8. Public Deployment Variant (effective 2026-08-15 on dsh.hi-ruofei.com): Semi-Shell
 
-> 本文档 §1-§7 为"插件形态"（门卫进 dsh 进程）。2026-08-15 生产实证后，公网实例改用
-> **半外壳**变体；长期方向见 `docs/dsh-auth-plan.md` §9 M5（独立反代外壳）。
+> §1–§7 of this document are the "plugin form" (the guard lives inside the dsh process). After
+> production validation on 2026-08-15, the public instance switches to the **semi-shell** variant;
+> the long-term direction is `docs/dsh-auth-plan.md` §9 M5 (independent reverse-proxy shell).
 
-### 8.1 为什么需要外壳：浏览器信任栅栏与认证正交
+### 8.1 Why a Shell Is Needed: The Browser-Trust Fence and Authentication Are Orthogonal
 
-dsh 0.1.0-rc.6 的 `dsh-client-connection` 把 `settings.*`/`credentials.*`/`llm.discoverModels`
-等 privileged 方法**钉死为仅 loopback**（PRIVILEGED_METHODS，`--trusted-host` 放不开）。
-公网反代下设置页的 `settings.describe`/`credentials.describe` 恒 403（"transport failure"），
-**与 dsh-auth-gate 无关**——移除门卫裸奔后 403 依旧（2026-08-15 实测）。
+`dsh-client-connection` in dsh 0.1.0-rc.6 **pins** privileged methods such as
+`settings.*`/`credentials.*`/`llm.discoverModels` to loopback only (PRIVILEGED_METHODS,
+`--trusted-host` cannot loosen this). Under a public reverse proxy, the settings page's
+`settings.describe`/`credentials.describe` always return 403 ("transport failure"),
+**unrelated to dsh-auth-gate** — removing the guard and running bare still returns 403
+(verified 2026-08-15).
 
-实测 header 矩阵（登录后 cookie 访问 `/api/settings.describe`）：
+Verified header matrix (cookie access to `/api/settings.describe` after login):
 
-| 上游 Host                       | Origin        | 结果 |
-| ------------------------------- | ------------- | ---- |
-| `dsh.hi-ruofei.com`（原样透传） | 任意          | 403  |
-| `127.0.0.1:3080`（重写）        | 匹配 loopback | 200  |
-| `127.0.0.1:3080`（重写）        | 剥离          | 200  |
-| `127.0.0.1:3080`（重写）        | 不匹配        | 403  |
+| Upstream Host                                  | Origin           | Result |
+| ---------------------------------------------- | ---------------- | ------ |
+| `dsh.hi-ruofei.com` (passed through unchanged) | any              | 403    |
+| `127.0.0.1:3080` (rewritten)                   | matches loopback | 200    |
+| `127.0.0.1:3080` (rewritten)                   | stripped         | 200    |
+| `127.0.0.1:3080` (rewritten)                   | does not match   | 403    |
 
-### 8.2 半外壳拓扑（当前生产）
+### 8.2 Semi-Shell Topology (current production)
 
 ```
-公网 dsh.hi-ruofei.com (Caddy, TLS)
+public dsh.hi-ruofei.com (Caddy, TLS)
   └─ reverse_proxy 127.0.0.1:3080 {
-         header_up Host 127.0.0.1:3080   # 重写 Host → dsh 视为 loopback
-         header_up -Origin                # 剥离 Origin → 通过栅栏 Origin 匹配
+         header_up Host 127.0.0.1:3080   # rewrite Host → dsh treats it as loopback
+         header_up -Origin                # strip Origin → passes the fence's Origin match
      }
-       └─ dsh web（含 dsh-auth-gate 门卫，认证逻辑不变）
+       └─ dsh web (with the dsh-auth-gate guard; authentication logic unchanged)
 ```
 
-- 效果：设置页 13 个 API 全 200、零 console 报错；登录/限速/吊销/Bearer 全保留；WS 101 正常。
-- 代价：dsh 浏览器信任栅栏被架空（Host 恒 loopback、Origin 恒缺）；由门卫补偿——会话 cookie
-  `SameSite=Lax` → 跨站/重绑定请求拿不到 cookie → 401。纵深防御从"栅栏 + 门卫"变为
-  "门卫 + SameSite"。
-- 回滚：`/etc/caddy/Caddyfile.bak.shell`（外壳前）与 `$DSH_HOME/cordis.patch.yml.bak`（门卫
-  停用态）已留档；还原后重启 dsh-web + reload caddy 即回插件形态。
+- Effect: all 13 settings-page APIs return 200 with zero console errors; login/rate
+  limiting/revocation/Bearer all preserved; WS returns 101 normally.
+- Cost: dsh's browser-trust fence is bypassed (Host always loopback, Origin always absent);
+  compensated by the guard — the session cookie's `SameSite=Lax` → cross-site/rebinding requests
+  get no cookie → 401. Defense in depth changes from "fence + guard" to "guard + SameSite".
+- Rollback: `/etc/caddy/Caddyfile.bak.shell` (pre-shell) and
+  `$DSH_HOME/cordis.patch.yml.bak` (guard-disabled state) are archived; after restoring, restart
+  dsh-web and reload caddy to return to the plugin form.
 
-### 8.3 运维注意（半外壳特有）
+### 8.3 Ops Notes (semi-shell specific)
 
-- 升级回归（§5）照跑；另加设置页冒烟：登录后点「设置」，确认无 `transport failure`、
-  无 403 console 报错。
-- `--trusted-host dsh.hi-ruofei.com` 在重写后已冗余（Host 恒 loopback），保留无害。
-- 会话仍为内存态：dsh-web 重启后所有浏览器需重新登录（旧 cookie 一律 401，属 fail-closed 正常）。
-- 裸奔测试教训：**不要**在无外壳无门卫状态下公网运行——agent 有工作区写权限且
-  `$DSH_HOME/.credentials.yaml` 含模型 API key，任何人可白嫖调用。
+- Run the upgrade regression (§5) as usual; additionally smoke-test the settings page: after
+  login, click "Settings" and confirm there is no `transport failure` and no 403 console errors.
+- `--trusted-host dsh.hi-ruofei.com` is already redundant after the rewrite (Host always
+  loopback), but keeping it is harmless.
+- Sessions are still in-memory: after a dsh-web restart every browser must log in again (all old
+  cookies return 401, which is normal fail-closed behavior).
+- Bare-running lesson: **do not** run bare in public without the shell and without the guard —
+  agents have workspace write access and `$DSH_HOME/.credentials.yaml` contains model API keys,
+  so anyone could freely invoke them.

--- a/docs/deployment_zh.md
+++ b/docs/deployment_zh.md
@@ -1,0 +1,196 @@
+# dsh-auth-gate 部署与验收清单
+
+本文档描述如何把 dsh-auth-gate（password 模式，M3）部署到一个公网 dsh web 实例，并完成
+**部署验收**。适用于：实例已跑通 dsh web（`dsh --profile web`），需要加认证门。
+
+设计依据：`docs/dsh-auth-plan_zh.md` §7/§8（无上游 PR 通道的限制、纵深防御）；
+规格：`docs/impl-m2_zh.md`（token 模式）、`docs/impl-m3_zh.md`（password 模式）。
+**两个模式二选一**：下面按 password 模式（推荐，M3）编写；token 模式只需跳过
+"建用户"一步并配置 `tokenRef`。
+
+---
+
+## 0. 前置条件
+
+- **TLS 前置终结**（Nginx/Caddy 反代或 LB）：`cookieSecure: true` 依赖 https，否则浏览器
+  不保存会话 cookie（curl/脚本不受影响）。http-only 环境只能 `cookieSecure: false`（仅测试）。
+- **`--trusted-host` 与认证正交**：`--trusted-host` 只是 DNS-rebinding 防栏，不是认证；
+  两者都需配置。公网实例：`--trusted-host <域名>` 指到你的域名。
+- **低权限 OS 用户**运行 dsh（无 sudo、无其他项目文件）——plan §8 纵深防御第 1 条。
+- **服务器有 Node ≥ 22.19**（与部署一致）与 pnpm（`dsh plugin` 转发 pnpm）。实测：npm 默认
+  global prefix 是 `/usr`（无 root 权限装不了），用
+  `npm i -g pnpm --prefix ~/.npm-global` 并 `export PATH="$HOME/.npm-global/bin:$PATH"`
+  （`dsh` 本身也装在这个 prefix，见 `docs/handoff-m2_zh.md` §3.2）。
+
+---
+
+## 1. 安装 dsh-auth-gate（一次性）
+
+包已发布到 npm（`dsh-auth-gate`），一条命令装进目标 profile：
+
+```bash
+# 服务器（$DSH_HOME 指向目标实例，如 ~/.dsh 或隔离目录）：
+export PATH="$HOME/.npm-global/bin:$PATH"
+dsh plugin --profile web add dsh-auth-gate   # 转发 pnpm，从公共 npm 解析（实测）
+```
+
+- 安装后 `$DSH_HOME/profiles/web/package.json` 的 `dependencies` 含 `dsh-auth-gate`；
+  依赖（`yaml`、`@deepseek-ai/*`）自动从公共 npm 解析。
+- 升级：重跑同一命令（pnpm 拉新版本）。
+- 卸载：`dsh plugin --profile web remove dsh-auth-gate`（同时删 overlay 行）。
+
+## 2. 配置
+
+1. **建管理员**（`users.yaml` 自动创建于 `$DSH_HOME/auth/users.yaml`，0600）：
+   ```bash
+   printf '%s\n' '<强口令>' | dsh-auth user add admin --password-stdin
+   dsh-auth user list                    # 确认
+   ```
+   多管理员：重复 `user add`；禁用：`dsh-auth user disable <name>`。
+2. **overlay**：把仓库 `deploy/cordis.patch.yml` 复制为 `$DSH_HOME/cordis.patch.yml`，
+   按需调整（`cookieSecure` 必须与 TLS 环境一致；非默认路径才设 `usersFile`）。
+3. 确认无其他行占用 `dsh-auth-gate` id（patch 栈按 id 覆盖）。
+
+## 3. 启动与健康检查
+
+```bash
+cd "$DSH_HOME" && DSH_HOME="$DSH_HOME" setsid dsh --profile web --port 3081 \
+  > ~/dsh.log 2>&1 < /dev/null &                         # 等 ~25s
+tail -f ~/dsh.log                                        # 期望：无 error
+```
+
+（实测：SSH 会话里 `nohup ... &` 可能因子进程持有 fd 让 ssh 挂起 2 分钟——**挂起不代表失败**，
+`setsid` 可立即返回；启动后另开连接检查 `pgrep` 与端口。停止：
+`pkill -f "[d]sh --profile web"`——括号技巧防自杀，kill 与启动分两个连接。）
+
+启动自检（M1）：四类入口未全覆盖会 **fail loud**（进程启动失败并报
+`guard self-check failed`）——启动成功即守卫在位。日志应出现
+`session domain opened: dsh_auth_sessions`；无 `user store unavailable` /
+`users file not found`（首次登录前该 warn 正常——文件缺失=空用户集，fail-closed）。
+
+## 4. 验收清单（部署后逐项执行）
+
+服务器本机（或经 SSH 隧道）执行。`jar` 是 curl cookie jar；`<TOKEN>` 是登录响应
+`set-cookie` 里的 `dsh_auth` 值（43 字符）。
+
+```bash
+# A. 登录页与守卫
+curl -s -o /dev/null -w "%{http_code}\n" http://127.0.0.1:3081/auth/login          # 200
+curl -s http://127.0.0.1:3081/auth/login | grep -o 'name="username"'                # 命中
+
+# B. 未认证拒绝（导航 302 / API 401）
+curl -s -o /dev/null -w "%{http_code}\n" -H "Accept: text/html" http://127.0.0.1:3081/__dsh_api  # 302
+curl -s -o /dev/null -w "%{http_code}\n" -H "Accept: application/json" http://127.0.0.1:3081/__dsh_api  # 401
+
+# C. 登录（错 → 401；对 → 302 + set-cookie）
+curl -s -o /dev/null -w "%{http_code}\n" -d "username=admin&password=wrong" http://127.0.0.1:3081/auth/login  # 401
+curl -s -i -d "username=admin&password=<口令>" -c jar http://127.0.0.1:3081/auth/login | head -3  # 302 + set-cookie
+
+# D. 会话 cookie 与 Bearer 会话 token
+curl -s -o /dev/null -w "%{http_code}\n" -b jar http://127.0.0.1:3081/__dsh_api      # 200
+curl -s -b jar http://127.0.0.1:3081/auth/status                                     # {"authenticated":true}
+curl -s -o /dev/null -w "%{http_code}\n" -H "Authorization: Bearer <TOKEN>" http://127.0.0.1:3081/__dsh_api  # 200
+
+# E. 路由纪律（/auth 兜底不落 SPA fallback；method 纪律）
+curl -s -o /dev/null -w "%{http_code}\n" http://127.0.0.1:3081/auth/whatever         # 404
+curl -s -o /dev/null -w "%{http_code}\n" -X DELETE http://127.0.0.1:3081/auth/login  # 405
+
+# F. WS 升级通道（首行状态即可；--max-time 超时退出正常）
+curl --http1.1 -s -i --max-time 2 -b jar -H "Connection: Upgrade" -H "Upgrade: websocket" \
+  -H "Sec-WebSocket-Key: $(openssl rand -base64 16)" -H "Sec-WebSocket-Version: 13" \
+  http://127.0.0.1:3081/api/events.host | head -1                                    # 101
+# 无 cookie 变体 → 首行 401
+
+# G. 登出与吊销
+curl -s -i -X POST "http://127.0.0.1:3081/auth/logout?next=/" -b jar | head -3        # 302 + Max-Age=0
+curl -s -o /dev/null -w "%{http_code}\n" -b jar http://127.0.0.1:3081/__dsh_api      # 401
+
+# H. 限速（放在最后——锁定 30s 起）
+for i in 1 2 3 4 5 6; do curl -s -o /dev/null -w "%{http_code}\n" -d "username=admin&password=wrong" \
+  http://127.0.0.1:3081/auth/login; done       # 第 1~N 次 401，锁定后 429（IP 桶会累计此前失败）
+curl -s -i -d "username=admin&password=<口令>" http://127.0.0.1:3081/auth/login | head -3  # 429 + retry-after
+
+# I. 浏览器通路（可选，须 https 环境）：无痕窗口访问 → 302 到 /auth/login →
+#    登录 → 进入实例；登出按钮未实现，URL 访问 /auth/logout?next=/ 登出。
+```
+
+预期全绿 = 部署验收通过。**全部失败路径必须是失败**（401/403 语义不吞错）——任何"静默放行"
+（未认证拿到 200/101）都是部署错误。实测注：`cookieSecure: true` 只影响浏览器（curl 的
+cookie jar 不检查 `Secure`，验收序列照常）；H 组的锁定次数会累计此前步骤的失败（如 C 的
+`wrong` 一次）——以 `429 + retry-after` 出现为准。
+
+## 5. 升级与回归（dsh 升级必做）
+
+守卫包装依赖 `webServer` 非契约内部结构（plan §7）——**每次 dsh 升级后**：
+
+1. 启动（§3）——自检 fail loud 即失败；
+2. 跑验收清单 B/D/F 三组（守卫 + 会话 + WS）；
+3. 检查 `boot.log` 无新增 error/warn。
+
+## 6. 故障诊断
+
+| 症状                               | 原因                                              | 处理                                              |
+| ---------------------------------- | ------------------------------------------------- | ------------------------------------------------- |
+| 启动失败 `guard self-check failed` | 包装未覆盖全部入口（dsh 版本变化）                | 升级 dsh-auth-gate 或报告（勿绕过自检）           |
+| 登录恒 401                         | 口令错误 / 用户禁用 / users.yaml 缺失（空用户集） | `dsh-auth user list`；确认 `$DSH_HOME` 与实例一致 |
+| 登录 503 `user store unavailable`  | users.yaml 语法/schema 错、权限过宽（非 600）     | `chmod 600`；`dsh-auth user list` 复现错误信息    |
+| 登录 429                           | 限速锁定（内存态，重启清零）                      | 等 `retry-after` 或重启实例                       |
+| 浏览器登录后仍被拒                 | `cookieSecure: true` 但无 https                   | 补 TLS 前置，或临时 false（仅测试）               |
+| 认证后 API 仍 401                  | 反代没透传 cookie/Authorization                   | 检查反代 header 透传配置                          |
+
+## 7. 安全注意事项（plan §8 落地清单）
+
+- [ ] `$DSH_HOME/.credentials.yaml` 与 `auth/users.yaml` 均 `chmod 600`（dsh-auth CLI 自动 600）。
+- [ ] 会话日志视同含密材料（备份/共享同等防护）。
+- [ ] 升级回归（§5）纳入运维流程；auth 行健康检查（`boot.log` + 验收 B/D/F）纳入监控。
+- [ ] 口令哈希为 scrypt（`docs/impl-m3_zh.md` P1）；文件零明文。
+- [ ] 禁用用户只拦新登录（已发会话 TTL 内有效，M3 已知局限）。
+- [ ] 限速内存态重启清零；反代部署时限速按出口 IP 聚合（不信任 X-Forwarded-For）。
+
+## 8. 公网部署变体（2026-08-15 起，dsh.hi-ruofei.com 生效）：半外壳
+
+> 本文档 §1-§7 为"插件形态"（门卫进 dsh 进程）。2026-08-15 生产实证后，公网实例改用
+> **半外壳**变体；长期方向见 `docs/dsh-auth-plan_zh.md` §9 M5（独立反代外壳）。
+
+### 8.1 为什么需要外壳：浏览器信任栅栏与认证正交
+
+dsh 0.1.0-rc.6 的 `dsh-client-connection` 把 `settings.*`/`credentials.*`/`llm.discoverModels`
+等 privileged 方法**钉死为仅 loopback**（PRIVILEGED_METHODS，`--trusted-host` 放不开）。
+公网反代下设置页的 `settings.describe`/`credentials.describe` 恒 403（"transport failure"），
+**与 dsh-auth-gate 无关**——移除门卫裸奔后 403 依旧（2026-08-15 实测）。
+
+实测 header 矩阵（登录后 cookie 访问 `/api/settings.describe`）：
+
+| 上游 Host                       | Origin        | 结果 |
+| ------------------------------- | ------------- | ---- |
+| `dsh.hi-ruofei.com`（原样透传） | 任意          | 403  |
+| `127.0.0.1:3080`（重写）        | 匹配 loopback | 200  |
+| `127.0.0.1:3080`（重写）        | 剥离          | 200  |
+| `127.0.0.1:3080`（重写）        | 不匹配        | 403  |
+
+### 8.2 半外壳拓扑（当前生产）
+
+```
+公网 dsh.hi-ruofei.com (Caddy, TLS)
+  └─ reverse_proxy 127.0.0.1:3080 {
+         header_up Host 127.0.0.1:3080   # 重写 Host → dsh 视为 loopback
+         header_up -Origin                # 剥离 Origin → 通过栅栏 Origin 匹配
+     }
+       └─ dsh web（含 dsh-auth-gate 门卫，认证逻辑不变）
+```
+
+- 效果：设置页 13 个 API 全 200、零 console 报错；登录/限速/吊销/Bearer 全保留；WS 101 正常。
+- 代价：dsh 浏览器信任栅栏被架空（Host 恒 loopback、Origin 恒缺）；由门卫补偿——会话 cookie
+  `SameSite=Lax` → 跨站/重绑定请求拿不到 cookie → 401。纵深防御从"栅栏 + 门卫"变为
+  "门卫 + SameSite"。
+- 回滚：`/etc/caddy/Caddyfile.bak.shell`（外壳前）与 `$DSH_HOME/cordis.patch.yml.bak`（门卫
+  停用态）已留档；还原后重启 dsh-web + reload caddy 即回插件形态。
+
+### 8.3 运维注意（半外壳特有）
+
+- 升级回归（§5）照跑；另加设置页冒烟：登录后点「设置」，确认无 `transport failure`、
+  无 403 console 报错。
+- `--trusted-host dsh.hi-ruofei.com` 在重写后已冗余（Host 恒 loopback），保留无害。
+- 会话仍为内存态：dsh-web 重启后所有浏览器需重新登录（旧 cookie 一律 401，属 fail-closed 正常）。
+- 裸奔测试教训：**不要**在无外壳无门卫状态下公网运行——agent 有工作区写权限且
+  `$DSH_HOME/.credentials.yaml` 含模型 API key，任何人可白嫖调用。

--- a/docs/dsh-auth-plan.md
+++ b/docs/dsh-auth-plan.md
@@ -1,100 +1,86 @@
-# dsh-auth 可行性规划（v3，威胁模型修订）
+# dsh-auth feasibility plan (v3, threat model revision)
 
-> 目标：让公网部署的 dsh web 具备应用层认证能力，不依赖上游修改即可落地。
-> 状态：核心挂载点已用实时探针实测验证（探针 `authp-1` 已按用户要求 `cordis_undefine` 清理）。
-
----
-
-## 0. 已确认的决策（2026-08-14，v3）
-
-| #   | 决策                                                          | 影响                                                           |
-| --- | ------------------------------------------------------------- | -------------------------------------------------------------- |
-| 1   | **不做多用户/会话隔离**（保护对象是整个实例，而非用户间隐私） | 阶段 3 删除；`subject` 仅作审计；方案显著简化                  |
-| 2   | 会话必须跨重启持久化                                          | 用 storage domain（`dsh-storage-json` 已在组合中），见 §5      |
-| 3   | 无上游 PR 通道                                                | 包装挂载点长期化 → 自检/回归纪律；特权方法仍钉 loopback，见 §7 |
-| 4   | 探针清理                                                      | 已 `cordis_undefine`，无残留                                   |
-
-**分阶段路线（最终版）：**
-
-1. 阶段 1：随机 token 保护（共享口令）；
-2. 阶段 2：真正登录，凭证维护在配置文件中（多条目 = 多个管理员各自的凭证，互相不隔离）；
-3. 阶段 3：OTP（TOTP）加固。
+> Goal: give the publicly deployed dsh web application-layer authentication capability, landable without any upstream modification.
+> Status: core mount points verified in practice via live probe (probe `authp-1` cleaned up with `cordis_undefine` per user request).
 
 ---
 
-## 1. 威胁模型：这个门到底保护什么
+## 0. Confirmed decisions (2026-08-14, v3)
 
-修正后的认知：**auth 门保护的不是"API Key"这一项，而是整个 dsh 实例的单一入口**。未授权者
-一旦通过信任围栏（`--trusted-host`，它只是 DNS-rebinding 防栏，不是认证），可以触及：
+| #   | Decision                                                                                                  | Impact                                                                                                                          |
+| --- | --------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------- |
+| 1   | **No multi-user/session isolation** (the protected object is the entire instance, not inter-user privacy) | Phase 3 deleted; `subject` purely for audit; plan greatly simplified                                                            |
+| 2   | Sessions must persist across restarts                                                                     | Use a storage domain (`dsh-storage-json` already in the composition), see §5                                                    |
+| 3   | No upstream PR channel                                                                                    | Wrapping mount points becomes long-term → self-check/regression discipline; privileged methods still pinned to loopback, see §7 |
+| 4   | Probe cleanup                                                                                             | Already `cordis_undefine`d, no residue                                                                                          |
 
-| 资产         | 泄露途径                                                                                                                             |
-| ------------ | ------------------------------------------------------------------------------------------------------------------------------------ |
-| API Key 本身 | GUI 的 `credentials.describe` 被 loopback 钉死读不到；但 agent 的 bash 工具可直接 `cat ~/.dsh/.credentials.yaml`（除非文件沙箱拦截） |
-| LLM 额度     | 更现实的主要损失：不必偷 Key，直接开 agent 会话白嫖 API 额度（成本滥用）                                                             |
-| 全部会话历史 | 会话列表/内容 RPC 对所有过围栏的浏览器开放；agent shell 也可读 `sessions/*.jsonl`——可能含 agent 以往读入上下文的秘密                 |
-| 服务器 RCE   | agent 平面 = 任意 shell 执行（standard 预设的 bash 工具），等于服务器 shell 外送                                                     |
+**Phased roadmap (final version):**
 
-**关于工作区的澄清**：workspace 是 GUI 的组织概念，**不是访问控制边界**。所有会话都在同一个
-`DSH_HOME/sessions`，任何过了门的客户端都能看到并打开全部会话（包括他人的）。"客户端先加
-本地工作区"并不能阻止会话互读。若未来需要客户端间隐私，那才是多用户隔离——已决定不做。
-
-**推论**：单门模型（过了门 = 完整访问）与保护目标完全匹配，方案因此最简单；多用户隔离删除。
+1. Phase 1: random token protection (shared passphrase);
+2. Phase 2: real login, credentials maintained in a config file (multiple entries = each admin's own credentials, mutually non-isolated);
+3. Phase 3: OTP (TOTP) hardening.
 
 ---
 
-## 2. 结论
+## 1. Threat model: what this gate actually protects
 
-**可行，且已实测验证。** `webServer` 服务无中间件，但"请求时查表调 handler"的分发模型允许
-Host 插件**无上游改动**地对全部 HTTP 请求与全部 WS 升级做守卫包装。实测证据（探针已清理，
-结论留档）：
+Revised understanding: the **auth gate protects not just the "API Key" item but the single entry point of the entire dsh instance**. An unauthorized party who passes the trust fence (`--trusted-host`, which is only a DNS-rebinding barrier, not authentication) can reach:
 
-- fallback（SPA index）、`/api` 前缀（含动态插件 RPC 通道）、exact 路由、两个 WS 升级
-  （`/api/events.mux`、`/api/events.host`）全部可拦截，放行零扰动；
-- 包装"存量表 + 注册方法"双保险，不受组合行 apply 顺序影响。
+| Asset               | Exposure path                                                                                                                                                                                  |
+| ------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| The API Key itself  | The GUI's `credentials.describe` is pinned to loopback and can't be read; but the agent's bash tool can directly `cat ~/.dsh/.credentials.yaml` (unless blocked by the file sandbox)           |
+| LLM quota           | The more realistic main loss: no need to steal the Key — just open an agent session and freeload the API quota (cost abuse)                                                                    |
+| All session history | Session list/content RPCs are open to every browser that gets past the fence; the agent shell can also read `sessions/*.jsonl` — which may contain secrets agents previously read into context |
+| Server RCE          | The agent plane = arbitrary shell execution (the bash tool of the standard preset), which is the server shell exported outside                                                                 |
 
-实现形态：**静态 npm 包（`dsh-auth`）+ web profile 组合行**（生产）；动态插件仅原型（已排除：
-无 `node:crypto`/`fetch`、重启即失效）。
+**Clarification about workspaces**: the workspace is a GUI organizational concept, **not an access-control boundary**. All sessions live in the same `DSH_HOME/sessions`, and any client that passes the gate can see and open all sessions (including others'). "Adding a local workspace on the client side" cannot stop cross-session reading. If inter-client privacy were ever needed in the future, that would be multi-user isolation — already decided not to do.
 
----
-
-## 3. 现状盘点（要点，详见附录代码位置）
-
-- `webServer` 服务（`@deepseek-ai/dsh-host-webserver`）：`exact`/`prefixes`/`upgrades` 三表 +
-  唯一 `fallback` 席位；分发 exact → 最长前缀 → fallback → 404；重复 `(kind, path)` 抛错；
-  **无中间件概念**。
-- `@deepseek-ai/dsh-client-connection`：前缀路由 `/api`（桥接 `apiProxy`）+ 两个 WS 升级；
-  每请求先过 `isTrustedApiRequest` 信任围栏（防 DNS rebinding / 跨站）——**注释明确"不是认证"**。
-- `PRIVILEGED_METHODS`（17 个方法：`settings.*`、`credentials.*`、`agentPreset.*` 等）用空信任
-  列表钉死 loopback——注释原文："until a real authentication layer exists"。
-- `@deepseek-ai/dsh-host-frontend-static` 独占 fallback 服务 SPA dist。
-- 组合层：web profile 根为空，patch 栈 = bundle patches（dsh-base → dsh-web-app → dsh-deeptutor）
-  → profile 层 → `$DSH_HOME/cordis.patch.yml` → `--patch` 覆盖层；行按 id 覆盖。
-- 全依赖树无任何 auth 包/服务/事件；`/api` interceptor 只能接管命中端点且围栏在它之前 → 不能当门。
+**Corollary**: the single-gate model (past the gate = full access) matches the protection goal exactly, so the plan is therefore the simplest; multi-user isolation is deleted.
 
 ---
 
-## 4. 挂载点：`webServer` 守卫包装
+## 2. Conclusion
 
-### 4.1 原理
+**Feasible, and verified in practice.** The `webServer` service has no middleware, but its dispatch model of "look up the handler in a table per request" lets a Host plugin **with no upstream changes** guard-wrap all HTTP requests and all WS upgrades. Empirical evidence (probe already cleaned up, the conclusion is archived):
 
-在 Host 插件 `apply` 中：
+- fallback (SPA index), the `/api` prefix (including the dynamic-plugin RPC channel), exact routes, and both WS upgrades (`/api/events.mux`, `/api/events.host`) can all be intercepted, with zero perturbation on pass-through;
+- wrapping the "existing table + registration methods" double insurance is unaffected by the order in which composition rows apply.
 
-1. **包装存量**：遍历 `server.exact`/`server.prefixes`/`server.upgrades`，逐项把 `handler` 替换为
-   `guard(原始 handler)`；`server.fallback` 同样包装；
-2. **包装增量**：覆盖实例方法 `register`/`registerUpgrade`/`registerFallback`，未来注册自动进守卫；
-3. **守卫逻辑**拿 `(req, res)`（升级为 `(req, socket, head)`）：公共路径白名单 / 会话校验，
-   放行或自行写 302/401，WS 无效则直接拒绝握手（不进入 `ws` 协商）；
-4. **auth 自己的端点**（登录/回调/登出/状态）用包装前捕获的原始 `register` 注册，避免自拦；
-5. **生命周期可逆**：`ctx.effect` 里还原原始方法与表快照（停用/卸载即撤守卫）。
+Implementation shape: **a static npm package (`dsh-auth`) + a web profile composition row** (production); the dynamic plugin was prototype-only (excluded: no `node:crypto`/`fetch`, invalidates on restart).
 
-### 4.2 骨架（概念代码，静态包内写法）
+---
+
+## 3. Current-state inventory (points; full code locations in the appendix)
+
+- `webServer` service (`@deepseek-ai/dsh-host-webserver`): three tables `exact`/`prefixes`/`upgrades` + a single `fallback` slot; dispatch exact → longest prefix → fallback → 404; duplicate `(kind, path)` throws; **no middleware concept**.
+- `@deepseek-ai/dsh-client-connection`: prefix route `/api` (bridging `apiProxy`) + two WS upgrades; every request first passes the `isTrustedApiRequest` trust fence (against DNS rebinding / cross-site) — **the comment states explicitly "not authentication"**.
+- `PRIVILEGED_METHODS` (17 methods: `settings.*`, `credentials.*`, `agentPreset.*`, etc.) use an empty trust list to pin to loopback — comment original: "until a real authentication layer exists".
+- `@deepseek-ai/dsh-host-frontend-static` exclusively owns the fallback to serve the SPA dist.
+- Composition layer: the web profile root is empty, the patch stack = bundle patches (dsh-base → dsh-web-app → dsh-deeptutor) → profile layer → `$DSH_HOME/cordis.patch.yml` → `--patch` override layer; rows are overridden by id.
+- The entire dependency tree has no auth package/service/event; the `/api` interceptor can only take over hit endpoints and the fence precedes it → it cannot serve as the gate.
+
+---
+
+## 4. Mount point: `webServer` guard wrapping
+
+### 4.1 Principle
+
+In the Host plugin's `apply`:
+
+1. **Wrap the existing**: iterate `server.exact`/`server.prefixes`/`server.upgrades`, replacing each `handler` with `guard(original handler)`; wrap `server.fallback` the same way;
+2. **Wrap the incremental**: override the instance methods `register`/`registerUpgrade`/`registerFallback`, so future registrations automatically go through the guard;
+3. **Guard logic** takes `(req, res)` (for upgrades `(req, socket, head)`): public path whitelist / session validation, either allow or write its own 302/401, and for an invalid WS directly refuse the handshake (never entering `ws` negotiation);
+4. **auth's own endpoints** (login/callback/logout/status) are registered with the original `register` captured before wrapping, to avoid self-blocking;
+5. **Reversible lifecycle**: restore the original methods and table snapshots in `ctx.effect` (guard is withdrawn on deactivation/uninstall).
+
+### 4.2 Skeleton (concept code, written for the static package)
 
 ```js
 export function apply(ctx, config) {
   const server = ctx.webServer; // inject: ['webServer', ...]
   const guard = (kind) => (handler) => async (req, res) => {
     const pathname = String(req.url ?? "/").split("?")[0];
-    const decision = await ctx.auth.decide(req, { kind, pathname }); // auth 服务：白名单/会话/目标
+    const decision = await ctx.auth.decide(req, { kind, pathname }); // auth service: whitelist/session/target
     if (decision === "allow") return handler(req, res);
     if (decision === "redirect") {
       res.writeHead(302, { location: `/auth/login?next=${encodeURIComponent(pathname)}` });
@@ -124,190 +110,170 @@ export function apply(ctx, config) {
   server.register = (r) => orig.register({ ...r, handler: guard(r.kind)(r.handler) });
   server.registerUpgrade = (r) => orig.registerUpgrade({ ...r, handler: guardUpgrade(r.handler) });
   server.registerFallback = (h) => orig.registerFallback(guard("fallback")(h));
-  // auth 公共端点（orig.register）+ 自检 + 还原，见 §7/§8
+  // auth public endpoints (orig.register) + self-check + restore, see §7/§8
 }
 ```
 
-### 4.3 风险与纪律（无上游通道下长期适用）
+### 4.3 Risks and discipline (long-term applicable with no upstream channel)
 
-- 包装依赖 `WebServer` 内部字段与"请求时查表"行为，属非契约接口。**每次 dsh 升级必须回归**。
-- 启动自检：探针式检查四类入口是否被包装（未包装 = 裸奔，启动时报错并写日志）。
-- guard 代码集中在一个模块，未来上游若提供契约中间件，迁移面最小。
+- Wrapping depends on `WebServer` internal fields and the "look up at request time" behavior, which are non-contract interfaces. **Every dsh upgrade must be regressed.**
+- Startup self-check: probe-style check that all four entry classes are wrapped (unwrapped = bare-exposure; error at startup and write log).
+- The guard code is centralized in one module, so if upstream provides contract middleware in the future, the migration surface is minimal.
 
 ---
 
-## 5. 架构设计：门恒定、登录流可插拔
+## 5. Architecture design: gate constant, login flow pluggable
 
-关键设计：**守卫（gate）永远只做一件事**——查公共白名单、查会话 cookie、按目标写 302/401。
-"如何产生会话"是**可插拔的登录流（flow）**，按阶段叠加，不改门：
+Key design: the **guard (gate) always does exactly one thing** — check the public whitelist, check the session cookie, and write 302/401 by target. "How a session is produced" is a **pluggable login flow**, layered by phase, without changing the gate:
 
 ```
-请求 → guard → 白名单? ──是──→ 放行
-              └─否→ 会话 cookie 有效? ──是──→ 放行（subject 挂到请求上下文，仅审计用）
-                          └─否→ HTML 导航 → 302 /auth/login
-                               API/WS    → 401 / 拒握手
+request → guard → whitelist? ──yes──→ allow
+               └─no→ session cookie valid? ──yes──→ allow (subject attached to request context, audit only)
+                           └─no→ HTML navigation → 302 /auth/login
+                                API/WS    → 401 / refuse handshake
 
-登录流（按阶段启用）：
-  阶段1 token flow   : POST /auth/login {token} → 校验共享 token → 发会话
-  阶段2 password flow: POST /auth/login {username, password} → 查 users 文件(哈希) → 发会话
-  阶段3 otp flow     : password 通过后 + TOTP 校验 → 发会话（两段式）
+login flows (enabled per phase):
+  Phase-1 token flow   : POST /auth/login {token} → validate shared token → issue session
+  Phase-2 password flow: POST /auth/login {username, password} → look up users file (hash) → issue session
+  Phase-3 otp flow     : after password passes + TOTP validation → issue session (two-stage)
 ```
 
-- 会话记录带 `subject`（阶段 1 固定 `"token"`，阶段 2 为用户名），**用途是审计**（日志里知道
-  哪个凭证产生的会话），不是为隔离铺路。
-- 登录页由 auth 自服务（自包含 HTML 字符串，无第三方资源）：SPA 在门后，登录页不能依赖 SPA。
-- 浏览器侧所有后续请求自动带 cookie（fetch/WS 由上游客户端发出，我们不改客户端代码）。
+- Session records carry `subject` (fixed `"token"` in phase 1, the username in phase 2), **used for audit** (knowing in logs which credential produced the session), not paving the way for isolation.
+- The login page is self-served by auth (self-contained HTML string, no third-party resources): the SPA sits behind the gate, so the login page must not depend on the SPA.
+- All subsequent browser-side requests carry the cookie automatically (fetch/WS are issued by the upstream client; we don't change client code).
 
 ---
 
-## 6. 分阶段设计
+## 6. Phased design
 
-### 阶段 1：随机 token 保护
+### Phase 1: random token protection
 
-- 部署时生成高熵 token（如 `openssl rand -hex 32`），写入 `.credentials.yaml`（条目名如
-  `DSH_AUTH_TOKEN`），插件配置以 **credential 引用** 声明（`credentials` 服务只认环境变量名，
-  值从 `.credentials.yaml`/env 解析——与 dsh 既有秘密机制一致，配置面永不落值）。
-- 入口：`POST /auth/login`（自包含页面 + 表单）提交 token → 恒时比较 → 发会话 cookie；
-  另支持 `Authorization: Bearer <token>`（curl/脚本友好）直接通过守卫。
-- 会话：§5 的持久化 session + `HttpOnly; Secure; SameSite=Lax; Path=/`。
+- Generate a high-entropy token at deploy time (e.g. `openssl rand -hex 32`), write it into `.credentials.yaml` (entry name e.g. `DSH_AUTH_TOKEN`); the plugin config declares it as a **credential reference** (the `credentials` service only recognizes environment-variable names, resolving the value from `.credentials.yaml`/env — consistent with dsh's existing secret mechanism, the config surface never holds the value).
+- Entry: `POST /auth/login` (self-contained page + form) submits the token → constant-time comparison → issue session cookie; also supports `Authorization: Bearer <token>` (curl/script friendly) to pass the guard directly.
+- Session: §5's persistent session + `HttpOnly; Secure; SameSite=Lax; Path=/`.
 
-### 阶段 2：真正登录 + 配置文件凭证
+### Phase 2: real login + config-file credentials
 
-- 凭证文件：`$DSH_HOME/auth/users.yaml`（自建——settings/credentials 两条缝分别是命名空间/
-  单值模型，装不下用户表）。条目：`username → { passwordHash, totpSecret?, disabled? }`。
-  多条目的语义：**多个管理员各自的登录凭证**，互相完全可见（不做隔离）。
-- 口令哈希：**scrypt（`node:crypto` 内建，M3 实施选用——见 §9 路线图注）**；argon2id
-  （`@node-rs/argon2` 带预编译二进制）与 bcryptjs（纯 JS）为备选。**文件里永不出现明文口令**。
-- 配套管理 CLI：`dsh-auth user add/list/disable`（生成哈希、编辑 users.yaml）——避免手写哈希出错。
-- 登录限速：按 IP + 账号计数，失败指数退避；恒时比较。
+- Credentials file: `$DSH_HOME/auth/users.yaml` (self-created — the settings/credentials seams are a namespace/ single-value model respectively and can't fit a user table). Entry: `username → { passwordHash, totpSecret?, disabled? }`.
+  Multiple entries' semantics: **each admin's own login credential, fully visible to each other** (no isolation).
+- Password hashing: **scrypt (`node:crypto` built-in, chosen for M3 implementation — see §9 roadmap note)**; argon2id (`@node-rs/argon2` with a precompiled binary) and bcryptjs (pure JS) are alternatives. **Plaintext passwords never appear in files**.
+- Companion admin CLI: `dsh-auth user add/list/disable` (generate hash, edit users.yaml) — to avoid hand-writing hashes and getting them wrong.
+- Login rate limiting: count by IP + account, exponential backoff on failure; constant-time comparison.
 
-### 阶段 3：OTP（TOTP）
+### Phase 3: OTP (TOTP)
 
-- RFC 6238 TOTP：`node:crypto` HMAC 即可，静态包内无额外依赖。
-- users.yaml 增加 `totpSecret`；登录两段式：password 通过 → TOTP 挑战页 → 发会话。
-- 配置项：OTP 全局开关、按用户可选、尝试限速（TOTP 窗口 ±1，防重放记录最近验证码）。
+- RFC 6238 TOTP: `node:crypto` HMAC suffices, no extra dependency inside the static package.
+- Add `totpSecret` to users.yaml; two-stage login: password passes → TOTP challenge page → issue session.
+- Config items: OTP global switch, optional per-user, attempt rate limiting (TOTP window ±1, record recent verification codes for replay prevention).
 
-### （已删除）多用户会话隔离
+### (Deleted) multi-user session isolation
 
-不做。理由：威胁模型是"保护整个实例的单一入口"，门内所有人互信；会话互读在单门模型下
-不是问题。若未来真的需要客户端间隐私，需上游配合做会话归属过滤——届时单独立项。
+Not doing it. Reason: the threat model is "protect the single entry of the whole instance", where everyone inside the gate trusts each other; session cross-reading is not a problem in a single-gate model. If inter-client privacy were truly needed in the future, session ownership filtering would need upstream cooperation — a separate project then.
 
 ---
 
-## 7. 无上游 PR 通道的限制
+## 7. Limitations of having no upstream PR channel
 
-| 限制                                     | 影响                                                         | 对策                                                                                                        |
-| ---------------------------------------- | ------------------------------------------------------------ | ----------------------------------------------------------------------------------------------------------- |
-| 包装是**非契约接口**                     | dsh 升级可能改字段名/分发行为 → 静默失效即裸奔               | 启动自检（§4.3）+ 升级回归清单 + 盯 dsh 版本变更                                                            |
-| `PRIVILEGED_METHODS` **仍钉死 loopback** | 认证用户也无法从 GUI 改 settings/credentials（配置只能 SSH） | 接受（单门模型下影响小，反而把"门内人改配置"这条路堵住了）；可选 hacky 开关（守卫改写 Host 头解锁）默认关闭 |
-| 无 auth 事件/中间件                      | 需自建 `auth` 服务名 + 包装                                  | 无影响（宿主平面一行，单实例）                                                                              |
-| 登录页无法用 SPA 渲染                    | 预认证阶段 SPA 不可达                                        | 自包含 HTML 登录页（计划内）；认证后的会话状态/登出按钮可加 client 半边（browser 插件）做进 GUI             |
-| 信任围栏不认 auth                        | `--trusted-host` 仍需配置，两者正交叠加                      | 部署文档注明                                                                                                |
-
----
-
-## 8. 纵深防御与安全要点
-
-**与门正交、专门服务"保护 API Key"目标的措施：**
-
-- [ ] 服务器用**独立低权限 OS 用户**跑 dsh（无 sudo、无其他项目文件）——agent 平面若被攻破，
-      损失被限定在该用户；API Key 泄露影响面也最小
-- [ ] `.credentials.yaml` `chmod 600`；users.yaml 同样 600
-- [ ] 服务器部署的沙箱策略收紧（agent 工具限制在 workspace、不读 `DSH_HOME`）——注意会削弱
-      agent 能力，按需权衡；至少默认不读 `.credentials.yaml`
-- [ ] 会话日志视同**含密材料**（agent 可能把秘密读进过上下文）：备份/共享时同等防护
-
-**门本身的要点：**
-
-- [ ] 会话 token 只存 SHA-256 摘要；256-bit `crypto.randomBytes` 生成
-- [ ] Cookie：`HttpOnly; Secure; SameSite=Lax; Path=/`（Secure 依赖前置 TLS 终结）
-- [ ] 登录成功即换 token（防会话固定）；登出吊销并写盘
-- [ ] 登录限速（IP+账号，指数退避）；TOTP 防重放
-- [ ] 口令 scrypt（node:crypto 内建，M3 已实施），文件零明文
-- [ ] 恒时比较；日志不落 token/口令
-- [ ] fail-closed 纪律：auth 行禁用即裸奔 → 部署验收清单含"auth 行健康"检查
-- [ ] 自包含登录页（无 CDN/第三方资源）
-- [ ] dsh 升级回归：四类入口包装自检 + 登录流程冒烟
+| Limitation                                        | Impact                                                                                        | Countermeasure                                                                                                                                                                    |
+| ------------------------------------------------- | --------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Wrapping is a **non-contract interface**          | dsh upgrades may change field names/dispatch behavior → silent failure = bare exposure        | Startup self-check (§4.3) + upgrade regression checklist + keep an eye on dsh version changes                                                                                     |
+| `PRIVILEGED_METHODS` **still pinned to loopback** | Even authenticated users can't change settings/credentials from the GUI (config only via SSH) | Accept (small impact under the single-gate model; it even closes the "insiders change config" path); optional hacky switch (guard rewrites the Host header to unlock) default off |
+| No auth events/middleware                         | Must build the `auth` service name + wrapping ourselves                                       | No impact (one line on the host plane, single instance)                                                                                                                           |
+| Login page can't be rendered with the SPA         | SPA unreachable in the pre-auth stage                                                         | Self-contained HTML login page (planned); post-auth session state/logout button can add a client half (browser plugin) into the GUI                                               |
+| Trust fence doesn't know auth                     | `--trusted-host` still needs configuration; the two are orthogonal and stack                  | Note it in the deployment doc                                                                                                                                                     |
 
 ---
 
-## 9. 路线图
+## 8. Defense in depth and security points
 
-| 阶段 | 内容                                                                                | 交付物                                 |
-| ---- | ----------------------------------------------------------------------------------- | -------------------------------------- |
-| M0   | 探针验证挂载点                                                                      | ✅ 完成（探针已清理）                  |
-| M1   | `dsh-auth` 包骨架 + 守卫 + 启动自检 + 持久化会话（storage domain）                  | ✅ 完成：npm 包 host 半边 + profile 行 |
-| M2   | 阶段 1：随机 token 门（credentials 引用 + Bearer + 登录页发 cookie）                | ✅ 完成：可部署的公网最小防护          |
-| M3   | 阶段 2：users.yaml + 口令哈希（**scrypt**，见下注）+ 登录限速 + `dsh-auth user` CLI | ✅ 完成：真正登录                      |
-| M4   | 阶段 3：TOTP 两段式登录 + 配置项                                                    | OTP 加固                               |
-| M5   | 独立反代外壳模式（proxy shell）：自身监听公网 + 反代裸 dsh + Host/Origin 重写       | 规划中（2026-08-15 记录，待排期）      |
+**Measures orthogonal to the gate, specifically serving the "protect the API Key" goal:**
 
-> M3 注：口令哈希按用户拍板选用 `node:crypto` **scrypt**（N=2¹⁶/r=8/p=1，零新增原生依赖；
-> 规格 `docs/impl-m3.md` P1/P2），替代本节初稿中的 argon2id/bcryptjs 候选。
+- [ ] Server runs dsh under a **separate low-privilege OS user** (no sudo, no other project files) — if the agent plane is compromised, the damage is confined to that user; the API-Key leak blast radius is also minimized
+- [ ] `.credentials.yaml` `chmod 600`; users.yaml also 600
+- [ ] Tighten the sandbox policy of server deployment (agent tools restricted to the workspace, not reading `DSH_HOME`) — note this weakens agent capabilities, weigh as needed; at minimum don't read `.credentials.yaml` by default
+- [ ] Treat session logs as **secret-bearing materials** (agents may have read secrets into context): protect them equally when backing up/sharing
 
-### M5（规划）：独立反代外壳模式（standalone proxy shell）
+**Points about the gate itself:**
 
-> 2026-08-15 由生产部署实证驱动立项；排期前先读 `docs/deployment.md` §8（半外壳生产拓扑与
-> 栅栏事实表）。
-
-**背景（实证结论）**：dsh 0.1.0-rc.6 的浏览器信任栅栏把 `settings.*` / `credentials.*` /
-`llm.discoverModels` 等 privileged 方法钉死为仅 loopback（`dsh-client-connection`
-`PRIVILEGED_METHODS`，`--trusted-host` 放不开）。公网反代下这些端点恒 403。实测矩阵：
-
-| 上游 Host                   | Origin        | privileged API |
-| --------------------------- | ------------- | -------------- |
-| `dsh.hi-ruofei.com`（现状） | 任意          | 403            |
-| `127.0.0.1:3080`（重写）    | 匹配 loopback | 200            |
-| `127.0.0.1:3080`（重写）    | 剥离          | 200            |
-| `127.0.0.1:3080`（重写）    | 不匹配        | 403            |
-
-结论：**"让 dsh 以为自己在 loopback"与认证必须由同一层外壳承担**——只加认证壳而不重写
-Host/Origin 无效（栅栏与认证正交）。
-
-**目标**：dsh-auth-gate 增加独立部署形态——以 bare cordis 上下文启动（独立挂载范式见仓库根
-`.serve-login.tmp.mjs`），自身监听公网端口，内置反代到"裸 dsh"（零插件），自动重写
-Host/Origin 头；登录页/会话/限速/Bearer/登出沿用现有 gate 逻辑并覆盖代理入口。
-
-**收益**：
-
-- dsh 实例零插件零耦合；升级 dsh 无守卫兼容性风险（现插件形态每次升级须跑 deployment.md §5 回归）；
-- 设置页/凭证管理公网下完整可用（privileged 403 消失，无需 SSH 隧道）；
-- 外壳独立版本化、独立发布，与插件形态共享 gate/session 代码（需抽象公共层）。
-
-**技术要点**：
-
-- 代理层：cordis `webServer` 注册 catch-all 反代路由（转发 + header 重写）+ upgrade 通道透传（WS 101）；
-- header 规则（已实测）：`Host: 127.0.0.1:<上游端口>` + 剥离 `Origin`（或重写为 loopback
-  origin）；`Sec-Fetch-Site: cross-site` 仍被栅栏拒（保留，纵深防御）；跨站 cookie 由门卫
-  `SameSite=Lax` 兜底；
-- 会话 cookie `Secure` 依赖外壳 TLS 终结（沿用 deployment.md 前置条件）；
-- 形态入口建议：`dsh-auth proxy --upstream 127.0.0.1:3080 --port 8443`（password/token 模式配置不变）。
-
-**验收标准**（沿用 deployment.md §4 精神）：
-
-- 未认证：HTML 302 登录页 / API 401；登录后 `settings.describe`/`credentials.describe`/
-  `settings.update` 200；WS 带 cookie 101、无 cookie 401；
-- 公网浏览器全流程：登录 → 设置页零 transport failure → 聊天流式正常；
-- 裸 dsh 侧无插件、不需要 `--trusted-host`（Host 恒 loopback）。
-
-**依赖/风险**：
-
-- 反代需处理 streaming/SSE/WS/大 body（dsh 请求体上限 167772160 字节）；
-- 代理层是新攻击面：header 重写正确性优先；上游固定（127.0.0.1），SSRF 面小；
-- 与插件形态并存期维护双入口，spec 需先抽象公共 gate/session 层（建议 M5 首步）。
+- [ ] Session tokens stored only as SHA-256 digests; generated with 256-bit `crypto.randomBytes`
+- [ ] Cookie: `HttpOnly; Secure; SameSite=Lax; Path=/` (Secure relies on frontend TLS termination)
+- [ ] Rotate the token on every successful login (anti-session-fixation); logout revokes and writes to disk
+- [ ] Login rate limiting (IP+account, exponential backoff); TOTP replay prevention
+- [ ] Passwords scrypt (node:crypto built-in, implemented in M3), zero plaintext in files
+- [ ] Constant-time comparison; logs never record tokens/passwords
+- [ ] fail-closed discipline: if the auth row is disabled, it's bare exposure → deployment acceptance checklist includes an "auth row health" check
+- [ ] Self-contained login page (no CDN/third-party resources)
+- [ ] dsh upgrade regression: four entry-class wrapping self-check + login flow smoke test
 
 ---
 
-## 10. 附录：关键代码位置
+## 9. Roadmap
 
-| 事实                                    | 位置                                                                                                                                                  |
-| --------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `webServer`：路由表/注册/分发/升级监听  | `node_modules/@deepseek-ai/dsh-host-webserver/lib/index.js`（register L53、registerUpgrade L67、registerFallback L82、match L194、upgrade 监听 L132） |
-| `/api` 前缀路由 + 信任围栏 + WS 注册    | `node_modules/@deepseek-ai/dsh-client-connection/lib/index.js`（isTrustedApiRequest L184、/api 路由 L550-561、WS L566-585）                           |
-| PRIVILEGED_METHODS（loopback 钉死清单） | 同上 L504-520（意图注释 L485-503）                                                                                                                    |
-| SPA fallback 席位                       | `node_modules/@deepseek-ai/dsh-host-frontend-static/lib/index.js` L69-83                                                                              |
-| web 宿主组合（webserver/connection 行） | `node_modules/@deepseek-ai/dsh-web-app/cordis.patch.yml`（webserver L115-120、connection L156-163）                                                   |
-| storage domain 用法范式                 | `node_modules/@deepseek-ai/dsh-message-feedback/lib/types/spec.js` + `lib/index.js` L258-267                                                          |
-| credentials 引用模型（环境变量名）      | `node_modules/@deepseek-ai/dsh-credentials/lib/types/index.js`                                                                                        |
-| profile patch 层栈与 bundle 机制        | `dsh/lib/profile-boot-*.js`（composeProfile）                                                                                                         |
-| 本机 web profile bundles                | `C:\Users\Randal_Wang\.dsh\profiles\web\package.json`                                                                                                 |
+| Phase | Content                                                                                                                              | Deliverable                                        |
+| ----- | ------------------------------------------------------------------------------------------------------------------------------------ | -------------------------------------------------- |
+| M0    | Probe verification of mount points                                                                                                   | ✅ done (probe already cleaned up)                 |
+| M1    | `dsh-auth` package skeleton + guard + startup self-check + persistent sessions (storage domain)                                      | ✅ done: npm package host half + profile row       |
+| M2    | Phase 1: random token gate (credentials reference + Bearer + login page issues cookie)                                               | ✅ done: deployable minimal public protection      |
+| M3    | Phase 2: users.yaml + password hashing (**scrypt**, see note below) + login rate limiting + `dsh-auth user` CLI                      | ✅ done: real login                                |
+| M4    | Phase 3: TOTP two-stage login + config items                                                                                         | OTP hardening                                      |
+| M5    | Standalone reverse-proxy shell mode (proxy shell): listens on public net itself + reverse-proxies a bare dsh + Host/Origin rewriting | planned (recorded 2026-08-15, awaiting scheduling) |
+
+> M3 note: per the user's decision, password hashing uses `node:crypto` **scrypt** (N=2¹⁶/r=8/p=1, zero added native dependency; spec `docs/impl-m3.md` P1/P2), replacing the argon2id/bcryptjs candidates in the earlier draft of this section.
+
+### M5 (planned): standalone reverse-proxy shell mode (standalone proxy shell)
+
+> 2026-08-15 project initiation driven by production-deployment evidence; read `docs/deployment.md` §8 (semi-shell production topology and fence fact table) before scheduling.
+
+**Background (empirical findings)**: dsh 0.1.0-rc.6's browser trust fence pins privileged methods such as `settings.*` / `credentials.*` / `llm.discoverModels` to loopback only (`dsh-client-connection` `PRIVILEGED_METHODS`, which `--trusted-host` can't open up). Behind a public reverse proxy these endpoints are always 403. Measured matrix:
+
+| Upstream Host                 | Origin           | privileged API |
+| ----------------------------- | ---------------- | -------------- |
+| `dsh.hi-ruofei.com` (current) | any              | 403            |
+| `127.0.0.1:3080` (rewritten)  | matches loopback | 200            |
+| `127.0.0.1:3080` (rewritten)  | stripped         | 200            |
+| `127.0.0.1:3080` (rewritten)  | doesn't match    | 403            |
+
+Conclusion: **"making dsh believe it's on loopback" and authentication must both be borne by the same shell layer** — adding only an auth shell without rewriting Host/Origin is ineffective (the fence and auth are orthogonal).
+
+**Goal**: dsh-auth-gate adds a standalone deployment form — launched in a bare cordis context (standalone mount paradigm in repo-root `.serve-login.tmp.mjs`), listening on the public port itself, with a built-in reverse proxy to the "bare dsh" (zero plugins), automatically rewriting the Host/Origin headers; the login page/session/rate limiting/Bearer/logout reuse the existing gate logic and also cover the proxied entry.
+
+**Benefits**:
+
+- The dsh instance has zero plugins and zero coupling; upgrading dsh has no guard-compatibility risk (the current plugin form must run the deployment.md §5 regression on every upgrade);
+- Settings page/credential management fully usable behind public net (privileged 403 disappears, no SSH tunnel needed);
+- The shell is versioned and released independently, sharing the gate/session code with the plugin form (requires abstracting a common layer).
+
+**Technical points**:
+
+- Proxy layer: the cordis `webServer` registers a catch-all reverse-proxy route (forwarding + header rewriting) + upgrade-channel pass-through (WS 101);
+- Header rules (measured): `Host: 127.0.0.1:<upstream port>` + strip `Origin` (or rewrite to the loopback origin); `Sec-Fetch-Site: cross-site` is still rejected by the fence (keep, defense in depth); cross-site cookies are covered by the gate's `SameSite=Lax` fallback;
+- The session cookie's `Secure` relies on the shell's TLS termination (reusing deployment.md's precondition);
+- Form entry suggested: `dsh-auth proxy --upstream 127.0.0.1:3080 --port 8443` (password/token mode config unchanged).
+
+**Acceptance criteria** (echoing deployment.md §4's spirit):
+
+- Unauthenticated: HTML 302 to the login page / API 401; after login `settings.describe`/`credentials.describe`/`settings.update` 200; WS with cookie 101, no cookie 401;
+- Full public-browser flow: login → settings page with zero transport failures → chat streaming works;
+- Bare-dsh side has no plugins and doesn't need `--trusted-host` (Host always loopback).
+
+**Dependencies/risks**:
+
+- The reverse proxy must handle streaming/SSE/WS/large bodies (dsh request-body limit 167772160 bytes);
+- The proxy layer is a new attack surface: header-rewrite correctness is the priority; the upstream is fixed (`127.0.0.1`), so the SSRF surface is small;
+- During coexistence with the plugin form, two entry points must be maintained; the spec first needs to abstract the common gate/session layer (suggested as M5's first step).
+
+---
+
+## 10. Appendix: key code locations
+
+| Fact                                                              | Location                                                                                                                                                  |
+| ----------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `webServer`: route tables/registration/dispatch/upgrade listening | `node_modules/@deepseek-ai/dsh-host-webserver/lib/index.js` (register L53, registerUpgrade L67, registerFallback L82, match L194, upgrade listening L132) |
+| `/api` prefix route + trust fence + WS registration               | `node_modules/@deepseek-ai/dsh-client-connection/lib/index.js` (isTrustedApiRequest L184, /api route L550-561, WS L566-585)                               |
+| PRIVILEGED_METHODS (loopback-pinned list)                         | same file L504-520 (intent comment L485-503)                                                                                                              |
+| SPA fallback slot                                                 | `node_modules/@deepseek-ai/dsh-host-frontend-static/lib/index.js` L69-83                                                                                  |
+| web host composition (webserver/connection rows)                  | `node_modules/@deepseek-ai/dsh-web-app/cordis.patch.yml` (webserver L115-120, connection L156-163)                                                        |
+| storage domain usage pattern                                      | `node_modules/@deepseek-ai/dsh-message-feedback/lib/types/spec.js` + `lib/index.js` L258-267                                                              |
+| credentials reference model (environment-variable names)          | `node_modules/@deepseek-ai/dsh-credentials/lib/types/index.js`                                                                                            |
+| profile patch layer stack and bundle mechanism                    | `dsh/lib/profile-boot-*.js` (composeProfile)                                                                                                              |
+| local web profile bundles                                         | `C:\Users\Randal_Wang\.dsh\profiles\web\package.json`                                                                                                     |

--- a/docs/dsh-auth-plan_zh.md
+++ b/docs/dsh-auth-plan_zh.md
@@ -1,0 +1,313 @@
+# dsh-auth 可行性规划（v3，威胁模型修订）
+
+> 目标：让公网部署的 dsh web 具备应用层认证能力，不依赖上游修改即可落地。
+> 状态：核心挂载点已用实时探针实测验证（探针 `authp-1` 已按用户要求 `cordis_undefine` 清理）。
+
+---
+
+## 0. 已确认的决策（2026-08-14，v3）
+
+| #   | 决策                                                          | 影响                                                           |
+| --- | ------------------------------------------------------------- | -------------------------------------------------------------- |
+| 1   | **不做多用户/会话隔离**（保护对象是整个实例，而非用户间隐私） | 阶段 3 删除；`subject` 仅作审计；方案显著简化                  |
+| 2   | 会话必须跨重启持久化                                          | 用 storage domain（`dsh-storage-json` 已在组合中），见 §5      |
+| 3   | 无上游 PR 通道                                                | 包装挂载点长期化 → 自检/回归纪律；特权方法仍钉 loopback，见 §7 |
+| 4   | 探针清理                                                      | 已 `cordis_undefine`，无残留                                   |
+
+**分阶段路线（最终版）：**
+
+1. 阶段 1：随机 token 保护（共享口令）；
+2. 阶段 2：真正登录，凭证维护在配置文件中（多条目 = 多个管理员各自的凭证，互相不隔离）；
+3. 阶段 3：OTP（TOTP）加固。
+
+---
+
+## 1. 威胁模型：这个门到底保护什么
+
+修正后的认知：**auth 门保护的不是"API Key"这一项，而是整个 dsh 实例的单一入口**。未授权者
+一旦通过信任围栏（`--trusted-host`，它只是 DNS-rebinding 防栏，不是认证），可以触及：
+
+| 资产         | 泄露途径                                                                                                                             |
+| ------------ | ------------------------------------------------------------------------------------------------------------------------------------ |
+| API Key 本身 | GUI 的 `credentials.describe` 被 loopback 钉死读不到；但 agent 的 bash 工具可直接 `cat ~/.dsh/.credentials.yaml`（除非文件沙箱拦截） |
+| LLM 额度     | 更现实的主要损失：不必偷 Key，直接开 agent 会话白嫖 API 额度（成本滥用）                                                             |
+| 全部会话历史 | 会话列表/内容 RPC 对所有过围栏的浏览器开放；agent shell 也可读 `sessions/*.jsonl`——可能含 agent 以往读入上下文的秘密                 |
+| 服务器 RCE   | agent 平面 = 任意 shell 执行（standard 预设的 bash 工具），等于服务器 shell 外送                                                     |
+
+**关于工作区的澄清**：workspace 是 GUI 的组织概念，**不是访问控制边界**。所有会话都在同一个
+`DSH_HOME/sessions`，任何过了门的客户端都能看到并打开全部会话（包括他人的）。"客户端先加
+本地工作区"并不能阻止会话互读。若未来需要客户端间隐私，那才是多用户隔离——已决定不做。
+
+**推论**：单门模型（过了门 = 完整访问）与保护目标完全匹配，方案因此最简单；多用户隔离删除。
+
+---
+
+## 2. 结论
+
+**可行，且已实测验证。** `webServer` 服务无中间件，但"请求时查表调 handler"的分发模型允许
+Host 插件**无上游改动**地对全部 HTTP 请求与全部 WS 升级做守卫包装。实测证据（探针已清理，
+结论留档）：
+
+- fallback（SPA index）、`/api` 前缀（含动态插件 RPC 通道）、exact 路由、两个 WS 升级
+  （`/api/events.mux`、`/api/events.host`）全部可拦截，放行零扰动；
+- 包装"存量表 + 注册方法"双保险，不受组合行 apply 顺序影响。
+
+实现形态：**静态 npm 包（`dsh-auth`）+ web profile 组合行**（生产）；动态插件仅原型（已排除：
+无 `node:crypto`/`fetch`、重启即失效）。
+
+---
+
+## 3. 现状盘点（要点，详见附录代码位置）
+
+- `webServer` 服务（`@deepseek-ai/dsh-host-webserver`）：`exact`/`prefixes`/`upgrades` 三表 +
+  唯一 `fallback` 席位；分发 exact → 最长前缀 → fallback → 404；重复 `(kind, path)` 抛错；
+  **无中间件概念**。
+- `@deepseek-ai/dsh-client-connection`：前缀路由 `/api`（桥接 `apiProxy`）+ 两个 WS 升级；
+  每请求先过 `isTrustedApiRequest` 信任围栏（防 DNS rebinding / 跨站）——**注释明确"不是认证"**。
+- `PRIVILEGED_METHODS`（17 个方法：`settings.*`、`credentials.*`、`agentPreset.*` 等）用空信任
+  列表钉死 loopback——注释原文："until a real authentication layer exists"。
+- `@deepseek-ai/dsh-host-frontend-static` 独占 fallback 服务 SPA dist。
+- 组合层：web profile 根为空，patch 栈 = bundle patches（dsh-base → dsh-web-app → dsh-deeptutor）
+  → profile 层 → `$DSH_HOME/cordis.patch.yml` → `--patch` 覆盖层；行按 id 覆盖。
+- 全依赖树无任何 auth 包/服务/事件；`/api` interceptor 只能接管命中端点且围栏在它之前 → 不能当门。
+
+---
+
+## 4. 挂载点：`webServer` 守卫包装
+
+### 4.1 原理
+
+在 Host 插件 `apply` 中：
+
+1. **包装存量**：遍历 `server.exact`/`server.prefixes`/`server.upgrades`，逐项把 `handler` 替换为
+   `guard(原始 handler)`；`server.fallback` 同样包装；
+2. **包装增量**：覆盖实例方法 `register`/`registerUpgrade`/`registerFallback`，未来注册自动进守卫；
+3. **守卫逻辑**拿 `(req, res)`（升级为 `(req, socket, head)`）：公共路径白名单 / 会话校验，
+   放行或自行写 302/401，WS 无效则直接拒绝握手（不进入 `ws` 协商）；
+4. **auth 自己的端点**（登录/回调/登出/状态）用包装前捕获的原始 `register` 注册，避免自拦；
+5. **生命周期可逆**：`ctx.effect` 里还原原始方法与表快照（停用/卸载即撤守卫）。
+
+### 4.2 骨架（概念代码，静态包内写法）
+
+```js
+export function apply(ctx, config) {
+  const server = ctx.webServer; // inject: ['webServer', ...]
+  const guard = (kind) => (handler) => async (req, res) => {
+    const pathname = String(req.url ?? "/").split("?")[0];
+    const decision = await ctx.auth.decide(req, { kind, pathname }); // auth 服务：白名单/会话/目标
+    if (decision === "allow") return handler(req, res);
+    if (decision === "redirect") {
+      res.writeHead(302, { location: `/auth/login?next=${encodeURIComponent(pathname)}` });
+      return res.end();
+    }
+    res.writeHead(401);
+    return res.end("unauthorized");
+  };
+  const orig = {
+    register: server.register.bind(server),
+    registerUpgrade: server.registerUpgrade.bind(server),
+    registerFallback: server.registerFallback.bind(server),
+  };
+  const snap = {
+    exact: new Map(server.exact),
+    prefixes: new Map(server.prefixes),
+    upgrades: new Map(server.upgrades),
+    fallback: server.fallback,
+  };
+  for (const [p, r] of server.exact)
+    server.exact.set(p, { ...r, handler: guard("exact")(r.handler) });
+  for (const [p, r] of server.prefixes)
+    server.prefixes.set(p, { ...r, handler: guard("prefix")(r.handler) });
+  for (const [p, r] of server.upgrades)
+    server.upgrades.set(p, { ...r, handler: guardUpgrade(r.handler) });
+  if (server.fallback) server.fallback = guard("fallback")(server.fallback);
+  server.register = (r) => orig.register({ ...r, handler: guard(r.kind)(r.handler) });
+  server.registerUpgrade = (r) => orig.registerUpgrade({ ...r, handler: guardUpgrade(r.handler) });
+  server.registerFallback = (h) => orig.registerFallback(guard("fallback")(h));
+  // auth 公共端点（orig.register）+ 自检 + 还原，见 §7/§8
+}
+```
+
+### 4.3 风险与纪律（无上游通道下长期适用）
+
+- 包装依赖 `WebServer` 内部字段与"请求时查表"行为，属非契约接口。**每次 dsh 升级必须回归**。
+- 启动自检：探针式检查四类入口是否被包装（未包装 = 裸奔，启动时报错并写日志）。
+- guard 代码集中在一个模块，未来上游若提供契约中间件，迁移面最小。
+
+---
+
+## 5. 架构设计：门恒定、登录流可插拔
+
+关键设计：**守卫（gate）永远只做一件事**——查公共白名单、查会话 cookie、按目标写 302/401。
+"如何产生会话"是**可插拔的登录流（flow）**，按阶段叠加，不改门：
+
+```
+请求 → guard → 白名单? ──是──→ 放行
+              └─否→ 会话 cookie 有效? ──是──→ 放行（subject 挂到请求上下文，仅审计用）
+                          └─否→ HTML 导航 → 302 /auth/login
+                               API/WS    → 401 / 拒握手
+
+登录流（按阶段启用）：
+  阶段1 token flow   : POST /auth/login {token} → 校验共享 token → 发会话
+  阶段2 password flow: POST /auth/login {username, password} → 查 users 文件(哈希) → 发会话
+  阶段3 otp flow     : password 通过后 + TOTP 校验 → 发会话（两段式）
+```
+
+- 会话记录带 `subject`（阶段 1 固定 `"token"`，阶段 2 为用户名），**用途是审计**（日志里知道
+  哪个凭证产生的会话），不是为隔离铺路。
+- 登录页由 auth 自服务（自包含 HTML 字符串，无第三方资源）：SPA 在门后，登录页不能依赖 SPA。
+- 浏览器侧所有后续请求自动带 cookie（fetch/WS 由上游客户端发出，我们不改客户端代码）。
+
+---
+
+## 6. 分阶段设计
+
+### 阶段 1：随机 token 保护
+
+- 部署时生成高熵 token（如 `openssl rand -hex 32`），写入 `.credentials.yaml`（条目名如
+  `DSH_AUTH_TOKEN`），插件配置以 **credential 引用** 声明（`credentials` 服务只认环境变量名，
+  值从 `.credentials.yaml`/env 解析——与 dsh 既有秘密机制一致，配置面永不落值）。
+- 入口：`POST /auth/login`（自包含页面 + 表单）提交 token → 恒时比较 → 发会话 cookie；
+  另支持 `Authorization: Bearer <token>`（curl/脚本友好）直接通过守卫。
+- 会话：§5 的持久化 session + `HttpOnly; Secure; SameSite=Lax; Path=/`。
+
+### 阶段 2：真正登录 + 配置文件凭证
+
+- 凭证文件：`$DSH_HOME/auth/users.yaml`（自建——settings/credentials 两条缝分别是命名空间/
+  单值模型，装不下用户表）。条目：`username → { passwordHash, totpSecret?, disabled? }`。
+  多条目的语义：**多个管理员各自的登录凭证**，互相完全可见（不做隔离）。
+- 口令哈希：**scrypt（`node:crypto` 内建，M3 实施选用——见 §9 路线图注）**；argon2id
+  （`@node-rs/argon2` 带预编译二进制）与 bcryptjs（纯 JS）为备选。**文件里永不出现明文口令**。
+- 配套管理 CLI：`dsh-auth user add/list/disable`（生成哈希、编辑 users.yaml）——避免手写哈希出错。
+- 登录限速：按 IP + 账号计数，失败指数退避；恒时比较。
+
+### 阶段 3：OTP（TOTP）
+
+- RFC 6238 TOTP：`node:crypto` HMAC 即可，静态包内无额外依赖。
+- users.yaml 增加 `totpSecret`；登录两段式：password 通过 → TOTP 挑战页 → 发会话。
+- 配置项：OTP 全局开关、按用户可选、尝试限速（TOTP 窗口 ±1，防重放记录最近验证码）。
+
+### （已删除）多用户会话隔离
+
+不做。理由：威胁模型是"保护整个实例的单一入口"，门内所有人互信；会话互读在单门模型下
+不是问题。若未来真的需要客户端间隐私，需上游配合做会话归属过滤——届时单独立项。
+
+---
+
+## 7. 无上游 PR 通道的限制
+
+| 限制                                     | 影响                                                         | 对策                                                                                                        |
+| ---------------------------------------- | ------------------------------------------------------------ | ----------------------------------------------------------------------------------------------------------- |
+| 包装是**非契约接口**                     | dsh 升级可能改字段名/分发行为 → 静默失效即裸奔               | 启动自检（§4.3）+ 升级回归清单 + 盯 dsh 版本变更                                                            |
+| `PRIVILEGED_METHODS` **仍钉死 loopback** | 认证用户也无法从 GUI 改 settings/credentials（配置只能 SSH） | 接受（单门模型下影响小，反而把"门内人改配置"这条路堵住了）；可选 hacky 开关（守卫改写 Host 头解锁）默认关闭 |
+| 无 auth 事件/中间件                      | 需自建 `auth` 服务名 + 包装                                  | 无影响（宿主平面一行，单实例）                                                                              |
+| 登录页无法用 SPA 渲染                    | 预认证阶段 SPA 不可达                                        | 自包含 HTML 登录页（计划内）；认证后的会话状态/登出按钮可加 client 半边（browser 插件）做进 GUI             |
+| 信任围栏不认 auth                        | `--trusted-host` 仍需配置，两者正交叠加                      | 部署文档注明                                                                                                |
+
+---
+
+## 8. 纵深防御与安全要点
+
+**与门正交、专门服务"保护 API Key"目标的措施：**
+
+- [ ] 服务器用**独立低权限 OS 用户**跑 dsh（无 sudo、无其他项目文件）——agent 平面若被攻破，
+      损失被限定在该用户；API Key 泄露影响面也最小
+- [ ] `.credentials.yaml` `chmod 600`；users.yaml 同样 600
+- [ ] 服务器部署的沙箱策略收紧（agent 工具限制在 workspace、不读 `DSH_HOME`）——注意会削弱
+      agent 能力，按需权衡；至少默认不读 `.credentials.yaml`
+- [ ] 会话日志视同**含密材料**（agent 可能把秘密读进过上下文）：备份/共享时同等防护
+
+**门本身的要点：**
+
+- [ ] 会话 token 只存 SHA-256 摘要；256-bit `crypto.randomBytes` 生成
+- [ ] Cookie：`HttpOnly; Secure; SameSite=Lax; Path=/`（Secure 依赖前置 TLS 终结）
+- [ ] 登录成功即换 token（防会话固定）；登出吊销并写盘
+- [ ] 登录限速（IP+账号，指数退避）；TOTP 防重放
+- [ ] 口令 scrypt（node:crypto 内建，M3 已实施），文件零明文
+- [ ] 恒时比较；日志不落 token/口令
+- [ ] fail-closed 纪律：auth 行禁用即裸奔 → 部署验收清单含"auth 行健康"检查
+- [ ] 自包含登录页（无 CDN/第三方资源）
+- [ ] dsh 升级回归：四类入口包装自检 + 登录流程冒烟
+
+---
+
+## 9. 路线图
+
+| 阶段 | 内容                                                                                | 交付物                                 |
+| ---- | ----------------------------------------------------------------------------------- | -------------------------------------- |
+| M0   | 探针验证挂载点                                                                      | ✅ 完成（探针已清理）                  |
+| M1   | `dsh-auth` 包骨架 + 守卫 + 启动自检 + 持久化会话（storage domain）                  | ✅ 完成：npm 包 host 半边 + profile 行 |
+| M2   | 阶段 1：随机 token 门（credentials 引用 + Bearer + 登录页发 cookie）                | ✅ 完成：可部署的公网最小防护          |
+| M3   | 阶段 2：users.yaml + 口令哈希（**scrypt**，见下注）+ 登录限速 + `dsh-auth user` CLI | ✅ 完成：真正登录                      |
+| M4   | 阶段 3：TOTP 两段式登录 + 配置项                                                    | OTP 加固                               |
+| M5   | 独立反代外壳模式（proxy shell）：自身监听公网 + 反代裸 dsh + Host/Origin 重写       | 规划中（2026-08-15 记录，待排期）      |
+
+> M3 注：口令哈希按用户拍板选用 `node:crypto` **scrypt**（N=2¹⁶/r=8/p=1，零新增原生依赖；
+> 规格 `docs/impl-m3_zh.md` P1/P2），替代本节初稿中的 argon2id/bcryptjs 候选。
+
+### M5（规划）：独立反代外壳模式（standalone proxy shell）
+
+> 2026-08-15 由生产部署实证驱动立项；排期前先读 `docs/deployment_zh.md` §8（半外壳生产拓扑与
+> 栅栏事实表）。
+
+**背景（实证结论）**：dsh 0.1.0-rc.6 的浏览器信任栅栏把 `settings.*` / `credentials.*` /
+`llm.discoverModels` 等 privileged 方法钉死为仅 loopback（`dsh-client-connection`
+`PRIVILEGED_METHODS`，`--trusted-host` 放不开）。公网反代下这些端点恒 403。实测矩阵：
+
+| 上游 Host                   | Origin        | privileged API |
+| --------------------------- | ------------- | -------------- |
+| `dsh.hi-ruofei.com`（现状） | 任意          | 403            |
+| `127.0.0.1:3080`（重写）    | 匹配 loopback | 200            |
+| `127.0.0.1:3080`（重写）    | 剥离          | 200            |
+| `127.0.0.1:3080`（重写）    | 不匹配        | 403            |
+
+结论：**"让 dsh 以为自己在 loopback"与认证必须由同一层外壳承担**——只加认证壳而不重写
+Host/Origin 无效（栅栏与认证正交）。
+
+**目标**：dsh-auth-gate 增加独立部署形态——以 bare cordis 上下文启动（独立挂载范式见仓库根
+`.serve-login.tmp.mjs`），自身监听公网端口，内置反代到"裸 dsh"（零插件），自动重写
+Host/Origin 头；登录页/会话/限速/Bearer/登出沿用现有 gate 逻辑并覆盖代理入口。
+
+**收益**：
+
+- dsh 实例零插件零耦合；升级 dsh 无守卫兼容性风险（现插件形态每次升级须跑 deployment.md §5 回归）；
+- 设置页/凭证管理公网下完整可用（privileged 403 消失，无需 SSH 隧道）；
+- 外壳独立版本化、独立发布，与插件形态共享 gate/session 代码（需抽象公共层）。
+
+**技术要点**：
+
+- 代理层：cordis `webServer` 注册 catch-all 反代路由（转发 + header 重写）+ upgrade 通道透传（WS 101）；
+- header 规则（已实测）：`Host: 127.0.0.1:<上游端口>` + 剥离 `Origin`（或重写为 loopback
+  origin）；`Sec-Fetch-Site: cross-site` 仍被栅栏拒（保留，纵深防御）；跨站 cookie 由门卫
+  `SameSite=Lax` 兜底；
+- 会话 cookie `Secure` 依赖外壳 TLS 终结（沿用 deployment.md 前置条件）；
+- 形态入口建议：`dsh-auth proxy --upstream 127.0.0.1:3080 --port 8443`（password/token 模式配置不变）。
+
+**验收标准**（沿用 deployment.md §4 精神）：
+
+- 未认证：HTML 302 登录页 / API 401；登录后 `settings.describe`/`credentials.describe`/
+  `settings.update` 200；WS 带 cookie 101、无 cookie 401；
+- 公网浏览器全流程：登录 → 设置页零 transport failure → 聊天流式正常；
+- 裸 dsh 侧无插件、不需要 `--trusted-host`（Host 恒 loopback）。
+
+**依赖/风险**：
+
+- 反代需处理 streaming/SSE/WS/大 body（dsh 请求体上限 167772160 字节）；
+- 代理层是新攻击面：header 重写正确性优先；上游固定（127.0.0.1），SSRF 面小；
+- 与插件形态并存期维护双入口，spec 需先抽象公共 gate/session 层（建议 M5 首步）。
+
+---
+
+## 10. 附录：关键代码位置
+
+| 事实                                    | 位置                                                                                                                                                  |
+| --------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `webServer`：路由表/注册/分发/升级监听  | `node_modules/@deepseek-ai/dsh-host-webserver/lib/index.js`（register L53、registerUpgrade L67、registerFallback L82、match L194、upgrade 监听 L132） |
+| `/api` 前缀路由 + 信任围栏 + WS 注册    | `node_modules/@deepseek-ai/dsh-client-connection/lib/index.js`（isTrustedApiRequest L184、/api 路由 L550-561、WS L566-585）                           |
+| PRIVILEGED_METHODS（loopback 钉死清单） | 同上 L504-520（意图注释 L485-503）                                                                                                                    |
+| SPA fallback 席位                       | `node_modules/@deepseek-ai/dsh-host-frontend-static/lib/index.js` L69-83                                                                              |
+| web 宿主组合（webserver/connection 行） | `node_modules/@deepseek-ai/dsh-web-app/cordis.patch.yml`（webserver L115-120、connection L156-163）                                                   |
+| storage domain 用法范式                 | `node_modules/@deepseek-ai/dsh-message-feedback/lib/types/spec.js` + `lib/index.js` L258-267                                                          |
+| credentials 引用模型（环境变量名）      | `node_modules/@deepseek-ai/dsh-credentials/lib/types/index.js`                                                                                        |
+| profile patch 层栈与 bundle 机制        | `dsh/lib/profile-boot-*.js`（composeProfile）                                                                                                         |
+| 本机 web profile bundles                | `C:\Users\Randal_Wang\.dsh\profiles\web\package.json`                                                                                                 |

--- a/docs/handoff-m2.md
+++ b/docs/handoff-m2.md
@@ -1,171 +1,202 @@
-# dsh-auth M2 交接文档（session handoff）
+# dsh-auth M2 handoff document (session handoff)
 
-> 读者：在**新 session** 中执行 `docs/impl-m2.md` 的编码代理。本文件承载本 session 独有的
-> 环境事实与过程知识——仓库里没有、重新探索成本高或会踩坑的内容。
-> **阅读顺序：`AGENTS.md` → `docs/impl-m2.md` → 本文档**。
+> Reader: the coding agent executing `docs/impl-m2.md` in a **new session**. This document carries the
+> environment facts and process knowledge unique to this session — content that is not in the repo, would
+> be costly to re-derive, or would trip you up.
+> **Reading order: `AGENTS.md` → `docs/impl-m2.md` → this document**.
 
 ---
 
-## 1. 一句话现状
+## 1. Status in one sentence
 
-M1（守卫 + 持久化会话 + 自检）已交付并在**真实 Ubuntu 服务器上端到端验证通过**（四类入口全守卫、
-401/302 行为正确）；M2（共享 token 门 + 登录页 + Bearer）规格已冻结，待新 session 实施。
+M1 (guard + persistent session + self-check) is delivered and **verified end-to-end on a real Ubuntu
+server** (all four entry types guarded, 401/302 behavior correct); M2 (shared-token gate + login page +
+Bearer) spec is frozen, awaiting implementation by the new session.
 
-## 2. 仓库与远端状态快照（2026-08-14 晚）
+## 2. Repo and remote status snapshot (2026-08-14 evening)
 
-- 分支：`development`（开发唯一分支；`main` 只收 merge；**永不直接提交 main**）。
-- 远端 `origin/development` 已同步到 `4b5f712`（M1 全部提交已推，CI 对最新提交**全绿**）；无 open PR。
-- 本地 `development` 已含 M2 规格最终化（`c184dbc` + `bbe39bd`）与 **M2 实施提交**（未推）；工作区状态
-  以 `git status` 为准。提交历史：`02c6f73`（spec+skills 基线）→ `eedfda9`（deps）→ `168b41e`（M1 实现）
-  → `4b5f712`（spec 修正）→ `c184dbc`/`bbe39bd`（M2 规格最终化）→ M2 实施提交。
-- M2 实施后**提交纪律**：未获用户指令不 commit/push；commit 用 Conventional Commits；`lib/` 与 `src/`
-  同批提交（CI 有 parity gate）。
+- Branch: `development` (sole development branch; `main` only accepts merges; **never commit directly to
+  main**).
+- Remote `origin/development` is synced to `4b5f712` (all M1 commits pushed, CI **all green** for the
+  latest commit); no open PRs.
+- Local `development` includes the finalized M2 spec (`c184dbc` + `bbe39bd`) and the **M2 implementation
+  commits** (unpushed); the working-tree state is per `git status`. Commit history: `02c6f73` (spec+skills
+  baseline) → `eedfda9` (deps) → `168b41e` (M1 implementation) → `4b5f712` (spec fixes) → `c184dbc`/
+  `bbe39bd` (M2 spec finalization) → M2 implementation commits.
+- **Commit discipline** after M2 implementation: do not commit/push without user instruction; use
+  Conventional Commits; commit `lib/` and `src/` in the same batch (CI has a parity gate).
 
-## 3. 环境事实（新 session 必读）
+## 3. Environment facts (required reading for the new session)
 
-### 3.1 沙箱网络限制（关键！）
+### 3.1 Sandbox network limits (critical!)
 
-- **本机 loopback 不可达**：从执行环境 `node fetch`/`curl --noproxy` 访问 `127.0.0.1:*` 会超时；
-  经环境代理（`http_proxy=127.0.0.1:7890`，Clash）返回 502。**不要在本地起实例后尝试 curl 验证**。
-- 可用通道：**SSH 到 Ubuntu 服务器**（`ssh ubuntu`，别名指向 49.232.250.16，免密）——服务器上的
-  loopback 正常，所有 HTTP 验证在服务器端做。
-- `gh` CLI 可用（GitHub 认证正常）。
+- **Local loopback is unreachable**: accessing `127.0.0.1:*` from the execution environment via
+  `node fetch`/`curl --noproxy` times out; through the environment proxy (`http_proxy=127.0.0.1:7890`,
+  Clash) it returns 502. **Do not start an instance locally and try to verify with curl**.
+- Available channel: **SSH to the Ubuntu server** (`ssh ubuntu`, alias points to 49.232.250.16,
+  passwordless) — loopback on the server is fine; all HTTP verification happens on the server side.
+- `gh` CLI is available (GitHub auth works).
 
-### 3.2 Ubuntu 服务器（验证环境）
+### 3.2 Ubuntu server (verification environment)
 
-- `ssh ubuntu`：Linux VM，Node v24.19.0（原生 TS strip 支持），npm 11.17.0。
-- **dsh 已全局安装**：`~/.npm-global/bin/dsh`（用户级 prefix，版本 0.1.0-rc.6，与部署一致）。
-  注意 PATH 里没有，用全路径或 `export PATH="$HOME/.npm-global/bin:$PATH"`。
-- **冒烟实例**：`~/dsh-smoke/`（独立 DSH_HOME）+ `/tmp/dsh-auth-test/`（rsync 的 dsh-auth 工作树 +
-  `probe.mjs` 探针）。
-  - 启动：`cd ~/dsh-smoke && DSH_HOME=~/dsh-smoke ~/.npm-global/bin/dsh --profile web --port 3081`
-    （后台：`nohup ... > ~/dsh-smoke/boot.log 2>&1 < /dev/null &`，等 ~25s）。
-  - 停止：`ssh ubuntu 'pkill -f "dsh --profile web --port 3081"'`。
-  - 实例可能已被上一 session 停止——**每次使用前先检查**（`pgrep -f` / curl）。
-  - 该实例**无认证**（M1 门是惰性的），公网可达——只放测试数据。
-- overlay 机制：`~/dsh-smoke/cordis.patch.yml`（$DSH_HOME 层）→ `- insert: { id, name }` 行。
-  M1 冒烟在 overlay 里插了两行：`dsh-auth`（name = `/tmp/dsh-auth-test/lib/index.js`）+
-  `dsh-auth-smoke-probe`（探针：注册 `/__auth_probe` 路由 + 把 `ctx.auth.gate` 换成
-  "仅拒绝该路径" 的门，验证守卫包装与拒绝链）。M2 冒烟改此文件（见 §5）。
-- 服务器端 curl 序列（M1 已用，M2 照此扩展）：
+- `ssh ubuntu`: Linux VM, Node v24.19.0 (native TS strip support), npm 11.17.0.
+- **dsh is installed globally**: `~/.npm-global/bin/dsh` (user-level prefix, version 0.1.0-rc.6, matching
+  the deployment). Note it is not on PATH; use the full path or `export PATH="$HOME/.npm-global/bin:$PATH"`.
+- **Smoke instance**: `~/dsh-smoke/` (standalone DSH_HOME) + `/tmp/dsh-auth-test/` (rsynced dsh-auth
+  working tree + `probe.mjs` probe).
+  - Start: `cd ~/dsh-smoke && DSH_HOME=~/dsh-smoke ~/.npm-global/bin/dsh --profile web --port 3081`
+    (background: `nohup ... > ~/dsh-smoke/boot.log 2>&1 < /dev/null &`, wait ~25s).
+  - Stop: `ssh ubuntu 'pkill -f "dsh --profile web --port 3081"'`.
+  - The instance may have been stopped by the previous session — **check before each use**
+    (`pgrep -f` / curl).
+  - This instance is **unauthenticated** (the M1 gate is lazy) and public — only test data goes in.
+- Overlay mechanism: `~/dsh-smoke/cordis.patch.yml` (the $DSH_HOME layer) → `- insert: { id, name }`
+  lines. M1 smoke insert two lines: `dsh-auth` (name = `/tmp/dsh-auth-test/lib/index.js`) +
+  `dsh-auth-smoke-probe` (probe: registers a `/__auth_probe` route + swaps `ctx.auth.gate` for a
+  "reject only this path" gate, to verify the guard wrapping and rejection chain). M2 smoke edits this file
+  (see §5).
+- Server-side curl sequence (used for M1, extended the same way for M2):
   ```bash
   curl -s -o /dev/null -w "%{http_code}\n" http://127.0.0.1:3081/__auth_probe -H "Accept: application/json"   # 401
   curl -s -i http://127.0.0.1:3081/__auth_probe -H "Accept: text/html" | head -3                              # 302 + location
   curl -s -o /dev/null -w "%{http_code}\n" http://127.0.0.1:3081/                                            # 200
   ```
-  启动证据看 `boot.log`：`[smoke-probe-late]` 行列出四类入口守卫状态（G=guarded）。
+  Startup evidence is in `boot.log`: the `[smoke-probe-late]` line lists the guard status of the four entry
+  types (G=guarded).
 
-### 3.3 本机（源仓库机器）
+### 3.3 Local machine (source-repo machine)
 
-- dsh 安装：`/Users/randal/.volta/tools/image/node/24.13.1/lib/node_modules/@deepseek-ai/dsh/`；
-  包源码/类型在 `node_modules/@deepseek-ai/*`（0.1.0-rc.6）——M1 规格 §2 的权威事实都来自这里，
-  **规格已覆盖，不要重新探索**。
-- npm registry：本机 `NPM_CONFIG_REGISTRY` 指向内网镜像——**安装必须显式
-  `--registry=https://registry.npmjs.org/`**（AGENTS.md 规则，`lock:check` 会查）。
-- 源码仓库：`/Users/randal/source/dsh-auth/`（Node ≥ 22.19 要求，本机 24.x）。
+- dsh install: `/Users/randal/.volta/tools/image/node/24.13.1/lib/node_modules/@deepseek-ai/dsh/`;
+  package source/types are in `node_modules/@deepseek-ai/*` (0.1.0-rc.6) — all authoritative facts of M1
+  spec §2 come from here, **the spec already covers them, do not re-explore**.
+- npm registry: local `NPM_CONFIG_REGISTRY` points at an internal mirror — **installation must explicitly
+  use `--registry=https://registry.npmjs.org/`** (AGENTS.md rule, `lock:check` verifies it).
+- Source repo: `/Users/randal/source/dsh-auth/` (requires Node ≥ 22.19; local is 24.x).
 
-### 3.4 动态插件环境限制（为什么 M2 验证不走 create mode）
+### 3.4 Dynamic-plugin environment limits (why M2 verification does not go through create mode)
 
-本 session 实测：动态插件（cordis_define/cordis_run）里对服务实例的**函数型属性读取被包装**
-（每次读回新绑定副本）→ `fallback` 赋值不生效、函数身份标记读不回来 → 完整守卫（fallback +
-方法替换 + 自检）**无法在动态插件形态下运行**；且失败运行不回滚表包装。**M2 验证一律走
-本地集成测试 + 服务器端到端**，不要用动态插件。
+Measured this session: in dynamic plugins (cordis_define/cordis_run), **function-type property reads on a
+service instance are wrapped** (each read returns a new bound copy) → `fallback` assignment does not take
+effect, function identity markers cannot be read back → full guard (fallback + method replacement +
+self-check) **cannot run in the dynamic-plugin form**; and a failed run does not roll back table wrapping.
+**All M2 verification goes through local integration tests + server end-to-end; do not use dynamic
+plugins.**
 
-## 4. M1 实施踩坑清单（新 session 直接规避）
+## 4. M1 implementation gotcha checklist (the new session should avoid these directly)
 
-1. **cordis `ctx.effect` 回调立即执行**：effect 的 callback 在注册时同步执行并返回 disposer——
-   写假 ctx 测试时必须调用 callback 而不是只存数组（M1 曾因此 4 个测试假失败）。
-2. **domain 名约束**：`DomainSpec.name`/表名必须匹配 `/^[a-z][a-z0-9_]*$/`（**禁连字符**）；
-   `dsh_auth_sessions`（下划线）。违者 `defineDomain` 模块加载即抛。
-3. **异步 open 的 promise 拆分**：`opening = storageDomain.open(spec)` 与
-   `ready = opening.then(...)` 必须分开——`ready` 挂 `.then` 后解析为 `void`，disposer 要从
-   原始 `opening` 取 domain 来 close（否则泄漏）。
-4. **schemastery 可调用类型**：`Config({})` 运行时填默认值，但 TS 签名要求完整形状——
-   测试里用 `{} as AuthConfig`。
-5. **lint 摩擦**（strictest preset）：
-   - 无 await 的函数不要标 `async`（require-await error）；
-   - 方法引用分离调用 → `unbound-method`：用 `.bind(obj)`（接口方法）或 `Reflect.get` 绕开；
-   - `Function` 类型被禁（`no-unsafe-function-type`）→ `(...args: never[]) => unknown`；
-   - `max-lines-per-function` 80 行 → 大测试拆多个 `describe`；文件 ≤250 行；
-   - `noPropertyAccessFromIndexSignature`：`obj["key"]` 而非 `obj.key`（Record 类型）。
-6. **fakes 必须保真 promise 语义**：`open` 假实现要 `Promise.resolve/reject`（同步抛错/返回值
-   会暴露为同步错误，与真实行为不符）。
-7. **集成测试挂 storage 栈顺序**：`Storage` → `storage-json` → `storage-domain` → `WebServer` →
-   本插件；dispose 逆序。真实 WebServer 挂载即监听（`ctx.plugin(WebServer, {host, port: 0})`）。
+1. **cordis `ctx.effect` callbacks run immediately**: the effect callback executes synchronously when
+   registered and returns a disposer — when writing the fake-ctx tests you must invoke the callback rather
+   than just storing the array (M1 had 4 fake test failures because of this).
+2. **domain-name constraint**: `DomainSpec.name`/table name must match `/^[a-z][a-z0-9_]*$/`
+   (**no hyphens**); `dsh_auth_sessions` (underscore). Violations throw at `defineDomain` module load.
+3. **split the async open promise**: `opening = storageDomain.open(spec)` and
+   `ready = opening.then(...)` must be separate — after `.then` is attached, `ready` resolves to `void`,
+   and the disposer must take the domain from the original `opening` to close (otherwise it leaks).
+4. **schemastery callable types**: `Config({})` fills defaults at runtime, but the TS signature requires a
+   complete shape — use `{} as AuthConfig` in tests.
+5. **lint friction** (strictest preset):
+   - Functions without an await should not be marked `async` (require-await error);
+   - method references separated from the call → `unbound-method`: work around with `.bind(obj)`
+     (interface methods) or `Reflect.get`;
+   - `Function` type is forbidden (`no-unsafe-function-type`) → `(...args: never[]) => unknown`;
+   - `max-lines-per-function` 80 lines → split large tests into multiple `describe`s; file ≤250 lines;
+   - `noPropertyAccessFromIndexSignature`: `obj["key"]` rather than `obj.key` (Record types).
+6. **fakes must preserve faithful promise semantics**: the `open` fake implementation should use
+   `Promise.resolve/reject` (synchronous throws/values would surface as sync errors, unlike the real
+   behavior).
+7. **integration-test storage stack mounting order**: `Storage` → `storage-json` → `storage-domain` →
+   `WebServer` → this plugin; dispose in reverse. The real WebServer listens once mounted
+   (`ctx.plugin(WebServer, {host, port: 0})`).
 
-## 5. M2 服务器端到端冒烟工作流（DoD 第 4 项）
+## 5. M2 server end-to-end smoke workflow (DoD item 4)
 
-在 §3.2 基础上：
+On top of §3.2:
 
-1. 同步新代码：`rsync -az --exclude node_modules --exclude .git /Users/randal/source/dsh-auth/ ubuntu:/tmp/dsh-auth-test/`
-   （服务器上再 `cd /tmp/dsh-auth-test && npm install --registry=... && npm run build`——lib 必须重建）。
-2. 写测试凭证：服务器上 `mkdir -p ~/dsh-smoke && cat > ~/dsh-smoke/.credentials.yaml <<EOF
-DSH_AUTH_TOKEN: <随机测试值>
+1. Sync new code: `rsync -az --exclude node_modules --exclude .git /Users/randal/source/dsh-auth/ ubuntu:/tmp/dsh-auth-test/`
+   (then on the server `cd /tmp/dsh-auth-test && npm install --registry=... && npm run build` — lib must be
+   rebuilt).
+2. Write test credentials: on the server `mkdir -p ~/dsh-smoke && cat > ~/dsh-smoke/.credentials.yaml <<EOF
+DSH_AUTH_TOKEN: <random test value>
 EOF
 chmod 600 ~/dsh-smoke/.credentials.yaml`
-   （`dsh-credentials-local` 的 `assertOwnerOnly` 要求 0600，否则启动抛错！）
-3. overlay 的 `dsh-auth` 行加 config：
+   (`dsh-credentials-local`'s `assertOwnerOnly` requires 0600, otherwise startup throws!).
+3. Add config to the overlay's `dsh-auth` line:
    ```yaml
    - insert:
        - id: dsh-auth
          name: "/tmp/dsh-auth-test/lib/index.js"
          config:
-           cookieSecure: false # http 测试环境；生产默认 true
+           cookieSecure: false # http test environment; production defaults true
    ```
-   **M1 遗留的探针行必须删除**（M2 实测：`probe.mjs` 会 `ctx.auth.gate = 自己的门`——保留则
-   `/__auth_probe` 测的是探针门而不是真实 TokenGate，冒烟全假）。`/__auth_probe` 路径本身仍可测
-   （无路由 → fallback → 被守卫 → 302/401；带 cookie → SPA 200）。
-4. 重启实例（§3.2），验证序列（在服务器上，cookie 用 `curl -c jar -b jar` 维护）：
-   - `GET /__auth_probe` 无 cookie：HTML accept → 302；JSON accept → 401（**这次是真的守卫**，不再是探针门）；
-   - `GET /auth/login` → 200 HTML；`GET /auth/whatever` → 404（兜底，非 SPA fallback）；
-     `DELETE /auth/login` → 405；
-   - `POST /auth/login` 错 token → 401；对 token（`-d "token=<v>" -c jar`）→ 302 + `set-cookie`；
-   - 带 cookie 再 `GET /__auth_probe`（`-b jar`）→ 200；
-   - `Authorization: Bearer <token>` → 200；
-   - WS 通道：`curl --http1.1 -s -i --max-time 2 -H "Connection: Upgrade" -H "Upgrade: websocket"
+   **The remaining M1 probe line must be deleted** (M2 verified: `probe.mjs` sets
+   `ctx.auth.gate = its own gate` — keeping it means `/__auth_probe` tests the probe gate rather than the
+   real TokenGate, so the smoke run is all fake). The `/__auth_probe` path itself is still testable (no
+   route → fallback → guarded → 302/401; with cookie → SPA 200).
+4. Restart the instance (§3.2), verification sequence (on the server, maintain the cookie with
+   `curl -c jar -b jar`):
+   - `GET /__auth_probe` no cookie: HTML accept → 302; JSON accept → 401 (**this time it is the real guard,
+     not the probe gate**);
+   - `GET /auth/login` → 200 HTML; `GET /auth/whatever` → 404 (fallback, not SPA fallback);
+     `DELETE /auth/login` → 405;
+   - `POST /auth/login` wrong token → 401; right token (`-d "token=<v>" -c jar`) → 302 + `set-cookie`;
+   - with cookie `GET /__auth_probe` again (`-b jar`) → 200;
+   - `Authorization: Bearer <token>` → 200;
+   - WS channel: `curl --http1.1 -s -i --max-time 2 -H "Connection: Upgrade" -H "Upgrade: websocket"
 -H "Sec-WebSocket-Key: $(openssl rand -base64 16)" -H "Sec-WebSocket-Version: 13"
-http://127.0.0.1:3081/api/events.host`：无 cookie → 首行 `HTTP/1.1 401`；`-b jar` →
-     首行 `HTTP/1.1 101`（`--max-time` 超时退出属正常，看首行即可）；
-   - `POST /auth/logout?next=/`（`-X POST -b jar`，无需 body/content-type）→ 302 + `Max-Age=0`；
-     原 cookie 再 `GET /__auth_probe` → 401。
-5. 收尾：杀掉实例或留用（报告状态）。
+http://127.0.0.1:3081/api/events.host`: no cookie → first line `HTTP/1.1 401`; `-b jar` →
+     first line `HTTP/1.1 101` (timing out via `--max-time` is normal; just look at the first line);
+   - `POST /auth/logout?next=/` (`-X POST -b jar`, no body/content-type needed) → 302 + `Max-Age=0`;
+     with the old cookie `GET /__auth_probe` again → 401.
+5. Wrap up: kill the instance or leave it running (report status).
 
-**M2 冒烟调试技巧（实测有效）**：
+**M2 smoke debugging tips (verified effective)**:
 
-- `dsh --profile web --dump-config` 看最终组合树（行 id、config、顺序），不必猜。
-- 诊断插件/路由**挂在 `/auth/*` 前缀下**（如 `/auth/__diag`）才能绕过门直接 curl——门白名单放行
-  `/auth/*`，exact 优先于兜底 prefix。
-- 插件内 `console.log` 会进 `boot.log`（`ctx.logger` 的输出不一定落盘）——诊断首选 console.log。
+- `dsh --profile web --dump-config` to see the final composited tree (line ids, config, order) — no need
+  to guess.
+- Mount diagnostic plugins/routes **under the `/auth/*` prefix** (e.g. `/auth/__diag`) to bypass the gate
+  and curl directly — the gate's allowlist passes `/auth/*`, exact beats the catch-all prefix.
+- `console.log` inside a plugin goes to `boot.log` (`ctx.logger` output is not guaranteed to be written to
+  disk) — prefer console.log for diagnostics.
 
-## 6. M2 特有执行注意（规格之外的提醒）
+## 6. M2-specific execution notes (reminders beyond the spec)
 
-- **凭证永不落日志**：token 值、session token 只出现在响应与内存；`resolveToken` 失败只记消息。
-- credentials 服务在 web 组合里由 `dsh-base` bundle 提供（`credentials` 行）——**不要自己挂**；
-  **集成测试不挂真实 provider**（规格 M18：零新增依赖）——用结构型假 provider
-  `ctx.provide("credentials", { resolve })` 先于本插件挂载；真实 provider 只在服务器冒烟覆盖
-  （§5.2 的 `.credentials.yaml`，记得 0600；env 层优先——`process.env.DSH_AUTH_TOKEN` 也可直接供冒烟）。
-- **挂载竞态（M2 冒烟实测，必读）**：harness **并行挂载行**——`credentials` 行（dsh-base）可能在
-  dsh-auth（用户层）apply **之后**才就绪。**不要在 apply 时读 `ctx.get("credentials")`**——解析器
-  必须每次 resolve 惰性现取（规格 §3.1/§4.6 已冻结）；否则真实组合里登录恒 401、Bearer 恒拒绝，
-  而集成测试（顺序挂载）全绿——冒烟才能暴露。`storageDomain` 无此竞态（与 webServer 同 bundle，
-  inject 保证可见）。
-- `mode: "password"` 在 M2 会抛错（fail loud）——规格 M11，别当成 bug。
-- **集成测试登录流程必须挂真实 storage 栈**（Storage → storage-json → storage-domain，见
-  `integration.auth.test.ts`）：只挂 WebServer 时 `auth.sessions` 恒 undefined → 登录恒 503
-  （fail-closed，不是 bug）——首次实现就踩了。
-- **lint 行数陷阱**：`max-lines` 计数 **skipBlankLines**（格式化后重排会把文件推过 250 上限，先
-  prettier 再数）；`max-lines-per-function` 把 describe 回调整体当函数计——大套件必须按 describe
-  拆（auth-endpoints 测试因此拆成三个文件）。
-- **`KvTable` 真实接口比 impl-m1 §2.2 列的多**：还要实现 `keys()` 与 `update()`，否则测试里
-  `implements KvTable` 直接类型错误（MemTable 以 session-store.test.ts 的为准）。
-- **eslint 类型解析退化**：`Array.isArray(x) ? x[0] : x` 再链式 `?.split()[0]` 会被判 `any`（
-  no-unsafe-* 报错）——用 `typeof x === "string"` 收窄（form-body.ts 踩过）。
-- **服务器进程管理**：`pkill -f "dsh --profile web --port 3081"` 会匹配到执行它的 shell 自身
-  （命令行含同样字符串）→ 自杀 + exit 255。用 `pkill -f "[d]sh --profile web --port 3081"`
-  （括号技巧），且 kill 与启动分两个 ssh 调用（启动命令的 nohup 行同样会命中 pkill）。
-- M2 完成后的下一步候选：正式生产 `cordis.patch.yml`（name 用 npm 包名而非路径）+ 部署验收清单
-  （plan §8：auth 行健康检查、TLS 前置、`--trusted-host` 正交说明）。
+- **Credentials never appear in logs**: token values and session tokens appear only in responses and
+  memory; `resolveToken` failures record only the message.
+- The credentials service in the web composite is provided by the `dsh-base` bundle (the `credentials`
+  line) — **do not mount your own**; **integration tests do not mount a real provider** (spec M18: zero new
+  dependencies) — use a structural fake provider `ctx.provide("credentials", { resolve })` mounted before
+  this plugin; the real provider is only covered by the server smoke run (§5.2's `.credentials.yaml`,
+  remember 0600; the env layer takes precedence — `process.env.DSH_AUTH_TOKEN` can also be fed directly to
+  the smoke run).
+- **Mount race (M2 smoke verified, must read)**: the harness **mounts lines in parallel** — the
+  `credentials` line (dsh-base) may become ready only **after** dsh-auth (user layer) applies. **Do not
+  read `ctx.get("credentials")` at apply time** — the resolver must lazily fetch fresh each resolve (spec
+  §3.1/§4.6 already frozen); otherwise in a real composite login is always 401 and Bearer always rejected,
+  while integration tests (sequential mount) are all green — only smoke exposes this. `storageDomain` has no
+  such race (same bundle as webServer; inject guarantees visibility).
+- `mode: "password"` throws in M2 (fail loud) — spec M11, do not treat it as a bug.
+- **The integration-test login flow must mount the real storage stack** (Storage → storage-json →
+  storage-domain, see `integration.auth.test.ts`): with only WebServer mounted, `auth.sessions` is always
+  undefined → login is always 503 (fail-closed, not a bug) — hit on the first implementation.
+- **lint line-count traps**: `max-lines` counts **skipBlankLines** (after formatting/reformatting the
+  file can be pushed past the 250 cap; prettier first, then count); `max-lines-per-function` counts the
+  whole describe callback as one function — large suites must be split per describe (the auth-endpoints
+  tests were therefore split into three files).
+- **`KvTable` real interface has more members than enumerated in impl-m1 §2.2**: you must also implement
+  `keys()` and `update()`, otherwise `implements KvTable` in tests is a direct type error (base MemTable on
+  session-store.test.ts).
+- **eslint type-narrowing degradation**: `Array.isArray(x) ? x[0] : x` followed by a chained
+  `?.split()[0]` is judged `any` (no-unsafe-* errors) — narrow with `typeof x === "string"`
+  (form-body.ts hit this).
+- **Server process management**: `pkill -f "dsh --profile web --port 3081"` matches the invoking shell
+  itself (its command line contains the same string) → self-kill + exit 255. Use
+  `pkill -f "[d]sh --profile web --port 3081"` (the bracket trick), and do the kill and start as two
+  separate ssh calls (the nohup line of the start command would otherwise also match pkill).
+- Next step candidates after M2: production `cordis.patch.yml` (name uses the npm package name rather than
+  a path) + a deployment acceptance checklist (plan §8: auth line health checks, TLS prerequisite,
+  `--trusted-host` orthogonality note).
 
-## 7. 开放问题 / 待定
+## 7. Open questions / pending
 
-- 无阻塞项。候选后续：登录页 UX 打磨、`/auth/status` 接 GUI 登出按钮（client 半边）、M3 规格。
+- No blocking items. Candidate follow-ups: login-page UX polish, `/auth/status` wiring to the GUI logout
+  button (client side), M3 spec.

--- a/docs/handoff-m2_zh.md
+++ b/docs/handoff-m2_zh.md
@@ -1,0 +1,171 @@
+# dsh-auth M2 交接文档（session handoff）
+
+> 读者：在**新 session** 中执行 `docs/impl-m2_zh.md` 的编码代理。本文件承载本 session 独有的
+> 环境事实与过程知识——仓库里没有、重新探索成本高或会踩坑的内容。
+> **阅读顺序：`AGENTS.md` → `docs/impl-m2_zh.md` → 本文档**。
+
+---
+
+## 1. 一句话现状
+
+M1（守卫 + 持久化会话 + 自检）已交付并在**真实 Ubuntu 服务器上端到端验证通过**（四类入口全守卫、
+401/302 行为正确）；M2（共享 token 门 + 登录页 + Bearer）规格已冻结，待新 session 实施。
+
+## 2. 仓库与远端状态快照（2026-08-14 晚）
+
+- 分支：`development`（开发唯一分支；`main` 只收 merge；**永不直接提交 main**）。
+- 远端 `origin/development` 已同步到 `4b5f712`（M1 全部提交已推，CI 对最新提交**全绿**）；无 open PR。
+- 本地 `development` 已含 M2 规格最终化（`c184dbc` + `bbe39bd`）与 **M2 实施提交**（未推）；工作区状态
+  以 `git status` 为准。提交历史：`02c6f73`（spec+skills 基线）→ `eedfda9`（deps）→ `168b41e`（M1 实现）
+  → `4b5f712`（spec 修正）→ `c184dbc`/`bbe39bd`（M2 规格最终化）→ M2 实施提交。
+- M2 实施后**提交纪律**：未获用户指令不 commit/push；commit 用 Conventional Commits；`lib/` 与 `src/`
+  同批提交（CI 有 parity gate）。
+
+## 3. 环境事实（新 session 必读）
+
+### 3.1 沙箱网络限制（关键！）
+
+- **本机 loopback 不可达**：从执行环境 `node fetch`/`curl --noproxy` 访问 `127.0.0.1:*` 会超时；
+  经环境代理（`http_proxy=127.0.0.1:7890`，Clash）返回 502。**不要在本地起实例后尝试 curl 验证**。
+- 可用通道：**SSH 到 Ubuntu 服务器**（`ssh ubuntu`，别名指向 49.232.250.16，免密）——服务器上的
+  loopback 正常，所有 HTTP 验证在服务器端做。
+- `gh` CLI 可用（GitHub 认证正常）。
+
+### 3.2 Ubuntu 服务器（验证环境）
+
+- `ssh ubuntu`：Linux VM，Node v24.19.0（原生 TS strip 支持），npm 11.17.0。
+- **dsh 已全局安装**：`~/.npm-global/bin/dsh`（用户级 prefix，版本 0.1.0-rc.6，与部署一致）。
+  注意 PATH 里没有，用全路径或 `export PATH="$HOME/.npm-global/bin:$PATH"`。
+- **冒烟实例**：`~/dsh-smoke/`（独立 DSH_HOME）+ `/tmp/dsh-auth-test/`（rsync 的 dsh-auth 工作树 +
+  `probe.mjs` 探针）。
+  - 启动：`cd ~/dsh-smoke && DSH_HOME=~/dsh-smoke ~/.npm-global/bin/dsh --profile web --port 3081`
+    （后台：`nohup ... > ~/dsh-smoke/boot.log 2>&1 < /dev/null &`，等 ~25s）。
+  - 停止：`ssh ubuntu 'pkill -f "dsh --profile web --port 3081"'`。
+  - 实例可能已被上一 session 停止——**每次使用前先检查**（`pgrep -f` / curl）。
+  - 该实例**无认证**（M1 门是惰性的），公网可达——只放测试数据。
+- overlay 机制：`~/dsh-smoke/cordis.patch.yml`（$DSH_HOME 层）→ `- insert: { id, name }` 行。
+  M1 冒烟在 overlay 里插了两行：`dsh-auth`（name = `/tmp/dsh-auth-test/lib/index.js`）+
+  `dsh-auth-smoke-probe`（探针：注册 `/__auth_probe` 路由 + 把 `ctx.auth.gate` 换成
+  "仅拒绝该路径" 的门，验证守卫包装与拒绝链）。M2 冒烟改此文件（见 §5）。
+- 服务器端 curl 序列（M1 已用，M2 照此扩展）：
+  ```bash
+  curl -s -o /dev/null -w "%{http_code}\n" http://127.0.0.1:3081/__auth_probe -H "Accept: application/json"   # 401
+  curl -s -i http://127.0.0.1:3081/__auth_probe -H "Accept: text/html" | head -3                              # 302 + location
+  curl -s -o /dev/null -w "%{http_code}\n" http://127.0.0.1:3081/                                            # 200
+  ```
+  启动证据看 `boot.log`：`[smoke-probe-late]` 行列出四类入口守卫状态（G=guarded）。
+
+### 3.3 本机（源仓库机器）
+
+- dsh 安装：`/Users/randal/.volta/tools/image/node/24.13.1/lib/node_modules/@deepseek-ai/dsh/`；
+  包源码/类型在 `node_modules/@deepseek-ai/*`（0.1.0-rc.6）——M1 规格 §2 的权威事实都来自这里，
+  **规格已覆盖，不要重新探索**。
+- npm registry：本机 `NPM_CONFIG_REGISTRY` 指向内网镜像——**安装必须显式
+  `--registry=https://registry.npmjs.org/`**（AGENTS.md 规则，`lock:check` 会查）。
+- 源码仓库：`/Users/randal/source/dsh-auth/`（Node ≥ 22.19 要求，本机 24.x）。
+
+### 3.4 动态插件环境限制（为什么 M2 验证不走 create mode）
+
+本 session 实测：动态插件（cordis_define/cordis_run）里对服务实例的**函数型属性读取被包装**
+（每次读回新绑定副本）→ `fallback` 赋值不生效、函数身份标记读不回来 → 完整守卫（fallback +
+方法替换 + 自检）**无法在动态插件形态下运行**；且失败运行不回滚表包装。**M2 验证一律走
+本地集成测试 + 服务器端到端**，不要用动态插件。
+
+## 4. M1 实施踩坑清单（新 session 直接规避）
+
+1. **cordis `ctx.effect` 回调立即执行**：effect 的 callback 在注册时同步执行并返回 disposer——
+   写假 ctx 测试时必须调用 callback 而不是只存数组（M1 曾因此 4 个测试假失败）。
+2. **domain 名约束**：`DomainSpec.name`/表名必须匹配 `/^[a-z][a-z0-9_]*$/`（**禁连字符**）；
+   `dsh_auth_sessions`（下划线）。违者 `defineDomain` 模块加载即抛。
+3. **异步 open 的 promise 拆分**：`opening = storageDomain.open(spec)` 与
+   `ready = opening.then(...)` 必须分开——`ready` 挂 `.then` 后解析为 `void`，disposer 要从
+   原始 `opening` 取 domain 来 close（否则泄漏）。
+4. **schemastery 可调用类型**：`Config({})` 运行时填默认值，但 TS 签名要求完整形状——
+   测试里用 `{} as AuthConfig`。
+5. **lint 摩擦**（strictest preset）：
+   - 无 await 的函数不要标 `async`（require-await error）；
+   - 方法引用分离调用 → `unbound-method`：用 `.bind(obj)`（接口方法）或 `Reflect.get` 绕开；
+   - `Function` 类型被禁（`no-unsafe-function-type`）→ `(...args: never[]) => unknown`；
+   - `max-lines-per-function` 80 行 → 大测试拆多个 `describe`；文件 ≤250 行；
+   - `noPropertyAccessFromIndexSignature`：`obj["key"]` 而非 `obj.key`（Record 类型）。
+6. **fakes 必须保真 promise 语义**：`open` 假实现要 `Promise.resolve/reject`（同步抛错/返回值
+   会暴露为同步错误，与真实行为不符）。
+7. **集成测试挂 storage 栈顺序**：`Storage` → `storage-json` → `storage-domain` → `WebServer` →
+   本插件；dispose 逆序。真实 WebServer 挂载即监听（`ctx.plugin(WebServer, {host, port: 0})`）。
+
+## 5. M2 服务器端到端冒烟工作流（DoD 第 4 项）
+
+在 §3.2 基础上：
+
+1. 同步新代码：`rsync -az --exclude node_modules --exclude .git /Users/randal/source/dsh-auth/ ubuntu:/tmp/dsh-auth-test/`
+   （服务器上再 `cd /tmp/dsh-auth-test && npm install --registry=... && npm run build`——lib 必须重建）。
+2. 写测试凭证：服务器上 `mkdir -p ~/dsh-smoke && cat > ~/dsh-smoke/.credentials.yaml <<EOF
+DSH_AUTH_TOKEN: <随机测试值>
+EOF
+chmod 600 ~/dsh-smoke/.credentials.yaml`
+   （`dsh-credentials-local` 的 `assertOwnerOnly` 要求 0600，否则启动抛错！）
+3. overlay 的 `dsh-auth` 行加 config：
+   ```yaml
+   - insert:
+       - id: dsh-auth
+         name: "/tmp/dsh-auth-test/lib/index.js"
+         config:
+           cookieSecure: false # http 测试环境；生产默认 true
+   ```
+   **M1 遗留的探针行必须删除**（M2 实测：`probe.mjs` 会 `ctx.auth.gate = 自己的门`——保留则
+   `/__auth_probe` 测的是探针门而不是真实 TokenGate，冒烟全假）。`/__auth_probe` 路径本身仍可测
+   （无路由 → fallback → 被守卫 → 302/401；带 cookie → SPA 200）。
+4. 重启实例（§3.2），验证序列（在服务器上，cookie 用 `curl -c jar -b jar` 维护）：
+   - `GET /__auth_probe` 无 cookie：HTML accept → 302；JSON accept → 401（**这次是真的守卫**，不再是探针门）；
+   - `GET /auth/login` → 200 HTML；`GET /auth/whatever` → 404（兜底，非 SPA fallback）；
+     `DELETE /auth/login` → 405；
+   - `POST /auth/login` 错 token → 401；对 token（`-d "token=<v>" -c jar`）→ 302 + `set-cookie`；
+   - 带 cookie 再 `GET /__auth_probe`（`-b jar`）→ 200；
+   - `Authorization: Bearer <token>` → 200；
+   - WS 通道：`curl --http1.1 -s -i --max-time 2 -H "Connection: Upgrade" -H "Upgrade: websocket"
+-H "Sec-WebSocket-Key: $(openssl rand -base64 16)" -H "Sec-WebSocket-Version: 13"
+http://127.0.0.1:3081/api/events.host`：无 cookie → 首行 `HTTP/1.1 401`；`-b jar` →
+     首行 `HTTP/1.1 101`（`--max-time` 超时退出属正常，看首行即可）；
+   - `POST /auth/logout?next=/`（`-X POST -b jar`，无需 body/content-type）→ 302 + `Max-Age=0`；
+     原 cookie 再 `GET /__auth_probe` → 401。
+5. 收尾：杀掉实例或留用（报告状态）。
+
+**M2 冒烟调试技巧（实测有效）**：
+
+- `dsh --profile web --dump-config` 看最终组合树（行 id、config、顺序），不必猜。
+- 诊断插件/路由**挂在 `/auth/*` 前缀下**（如 `/auth/__diag`）才能绕过门直接 curl——门白名单放行
+  `/auth/*`，exact 优先于兜底 prefix。
+- 插件内 `console.log` 会进 `boot.log`（`ctx.logger` 的输出不一定落盘）——诊断首选 console.log。
+
+## 6. M2 特有执行注意（规格之外的提醒）
+
+- **凭证永不落日志**：token 值、session token 只出现在响应与内存；`resolveToken` 失败只记消息。
+- credentials 服务在 web 组合里由 `dsh-base` bundle 提供（`credentials` 行）——**不要自己挂**；
+  **集成测试不挂真实 provider**（规格 M18：零新增依赖）——用结构型假 provider
+  `ctx.provide("credentials", { resolve })` 先于本插件挂载；真实 provider 只在服务器冒烟覆盖
+  （§5.2 的 `.credentials.yaml`，记得 0600；env 层优先——`process.env.DSH_AUTH_TOKEN` 也可直接供冒烟）。
+- **挂载竞态（M2 冒烟实测，必读）**：harness **并行挂载行**——`credentials` 行（dsh-base）可能在
+  dsh-auth（用户层）apply **之后**才就绪。**不要在 apply 时读 `ctx.get("credentials")`**——解析器
+  必须每次 resolve 惰性现取（规格 §3.1/§4.6 已冻结）；否则真实组合里登录恒 401、Bearer 恒拒绝，
+  而集成测试（顺序挂载）全绿——冒烟才能暴露。`storageDomain` 无此竞态（与 webServer 同 bundle，
+  inject 保证可见）。
+- `mode: "password"` 在 M2 会抛错（fail loud）——规格 M11，别当成 bug。
+- **集成测试登录流程必须挂真实 storage 栈**（Storage → storage-json → storage-domain，见
+  `integration.auth.test.ts`）：只挂 WebServer 时 `auth.sessions` 恒 undefined → 登录恒 503
+  （fail-closed，不是 bug）——首次实现就踩了。
+- **lint 行数陷阱**：`max-lines` 计数 **skipBlankLines**（格式化后重排会把文件推过 250 上限，先
+  prettier 再数）；`max-lines-per-function` 把 describe 回调整体当函数计——大套件必须按 describe
+  拆（auth-endpoints 测试因此拆成三个文件）。
+- **`KvTable` 真实接口比 impl-m1 §2.2 列的多**：还要实现 `keys()` 与 `update()`，否则测试里
+  `implements KvTable` 直接类型错误（MemTable 以 session-store.test.ts 的为准）。
+- **eslint 类型解析退化**：`Array.isArray(x) ? x[0] : x` 再链式 `?.split()[0]` 会被判 `any`（
+  no-unsafe-* 报错）——用 `typeof x === "string"` 收窄（form-body.ts 踩过）。
+- **服务器进程管理**：`pkill -f "dsh --profile web --port 3081"` 会匹配到执行它的 shell 自身
+  （命令行含同样字符串）→ 自杀 + exit 255。用 `pkill -f "[d]sh --profile web --port 3081"`
+  （括号技巧），且 kill 与启动分两个 ssh 调用（启动命令的 nohup 行同样会命中 pkill）。
+- M2 完成后的下一步候选：正式生产 `cordis.patch.yml`（name 用 npm 包名而非路径）+ 部署验收清单
+  （plan §8：auth 行健康检查、TLS 前置、`--trusted-host` 正交说明）。
+
+## 7. 开放问题 / 待定
+
+- 无阻塞项。候选后续：登录页 UX 打磨、`/auth/status` 接 GUI 登出按钮（client 半边）、M3 规格。

--- a/docs/handoff-m3.md
+++ b/docs/handoff-m3.md
@@ -1,113 +1,129 @@
-# dsh-auth M3 交接文档（session handoff）
+# dsh-auth M3 handoff document (session handoff)
 
-> 读者：在**新 session** 中执行 `docs/impl-m4.md` 的编码代理。本文件承载本 session 独有的
-> 环境事实与过程知识——仓库里没有、重新探索成本高或会踩坑的内容。
-> **阅读顺序：`AGENTS.md` → `docs/impl-m3.md` → 本文档**；`docs/handoff-m2.md` §3/§4 的
-> 环境事实（沙箱网络、服务器访问、pkill 技巧、lint 陷阱）依然有效，不重复。
+> Readers: the coding agent executing `docs/impl-m4.md` in a **new session**. This file carries
+> environment facts and procedural knowledge unique to this session — things not in the repo, that
+> are expensive to re-derive, or that will trip you up.
+> **Reading order: `AGENTS.md` → `docs/impl-m3.md` → this document**; the environment facts in
+> `docs/handoff-m2.md` §3/§4 (sandbox networking, server access, pkill tricks, lint pitfalls) are
+> still valid and are not repeated here.
 
 ---
 
-## 1. 一句话现状
+## 1. One-line status
 
-M3（password 模式：users.yaml + scrypt + 限速 + `dsh-auth user` CLI）已交付：`npm run verify`
-全绿（174 测试）、lib 同批、**真实服务器端到端冒烟全部通过**（登录/会话/Bearer 会话 token/
-WS/429 限速/禁用用户/白名单）。`mode: "token"`（M2）行为零改动、回归绿。
+M3 (password mode: users.yaml + scrypt + rate limiting + `dsh-auth user` CLI) is delivered: `npm run verify`
+is fully green (174 tests), lib is in the same commit, and **all real-server end-to-end smoke tests pass**
+(login/session/Bearer session token/WS/429 rate limiting/disabled user/whitelist). `mode: "token"` (M2) behavior
+is unchanged with zero regressions, all green.
 
-## 2. 仓库与远端状态快照（2026-08-15 下午，push 后）
+## 2. Repo and remote status snapshot (2026-08-15 afternoon, after push)
 
-- 分支：`development` 已与 `origin/development` 同步（9 个提交全部推送，
-  `git log --oneline origin/development..HEAD` 为空）：
-  - M2：`c184dbc`（spec 最终化）→ `bbe39bd`（handoff 快照）→ `aee37b4`（feat 实施）→
-    `6a5064e`（lazy credentials 文档）；
-  - M3：`1fac9fe`（spec）→ `db21eac`（feat 实施）→ `e030e75`（docs 契约/handoff）→
-    `5f049c2`（handoff 快照刷新 + plan 路线图 ✅）→ `04037a9`（部署交付物）。
-- **PR #2 已开**（`development` → `main`，标题 "M2 shared token gate + M3 password login
-  flow..."）：待合并。合并后 `main` 上的 `feat:` 提交会触发 release-please 自动开 **release
-  PR**（版本 bump + CHANGELOG，见 `docs/development.md` Releases）——那是自动化流程，无需
-  手工处理；release PR 合并前不要手工改 `package.json` 版本。
-- M3 实施期间的提交纪律照旧：`lib/` 与 `src/` 同批；`docs:`/`feat:` 分型。
+- Branch: `development` is in sync with `origin/development` (all 9 commits pushed,
+  `git log --oneline origin/development..HEAD` is empty):
+  - M2: `c184dbc` (spec finalized) → `bbe39bd` (handoff snapshot) → `aee37b4` (feat implementation) →
+    `6a5064e` (lazy credentials docs);
+  - M3: `1fac9fe` (spec) → `db21eac` (feat implementation) → `e030e75` (docs contract/handoff) →
+    `5f049c2` (handoff snapshot refresh + plan roadmap ✅) → `04037a9` (deployment deliverable).
+- **PR #2 is open** (`development` → `main`, titled "M2 shared token gate + M3 password login
+  flow..."): pending merge. After merge, the `feat:` commits on `main` will trigger release-please to
+  automatically open a **release PR** (version bump + CHANGELOG, see `docs/development.md` Releases) —
+  that is an automated flow and needs no manual handling; do not hand-edit the `package.json` version
+  before the release PR is merged.
+- Commit discipline during M3 implementation unchanged: `lib/` and `src/` in the same commit; `docs:`/`feat:`
+  split by type.
 
-## 3. M3 实施踩坑清单（新 session 直接规避）
+## 3. M3 implementation pitfall list (new session should avoid directly)
 
-1. **`deps.verify` 参数顺序**（必读，集成测试才暴露）：`PasswordLoginDeps.verify` 必须与
-   `verifyPassword` **同形 `(password, storedHash)`**。TS 结构兼容不检查参数名——写反了
-   单测（fake verify）全绿、**真实路径恒 401**（verifyPassword 把哈希串当口令解析段数失败）。
-   本 session 实测踩中，已在 `impl-m3.md` §4.7 标注。
-2. **effect 回调不得再包一层函数**（必读，所有集成测试 404 的根因）：`ctx.effect(() =>
-mountAuthEndpoints(...))` 里，mountAuthEndpoints 必须**立即执行注册并返回合并 disposer**；
-   若返回 `() => registerX(...)`，cordis 会把该函数当 disposer 存起来——注册永不发生，所有
-   `/auth/*` 恒 404 且**单测（fake ctx 同步 effect）与集成测试表现不同**，定位绕了远路。
-   已写进 `mountAuthEndpoints` 的 JSDoc。
-3. **CLI readLine 竞态**（服务器冒烟才暴露）：`createInterface` 的 `once("line")`/`once("close")`
-   在"管道数据先于 createInterface 到达并 EOF"时 close 可能先于 line → readLine 返回空串 →
-   CLI 报 `empty password`（**本机管道也复现**；`node -e` 单测复现不了因为无前置 await）。
-   修复：用 readline 的 **async iterator**（`for await (const line of lines) return line`）。
-   `cli.test.ts` 的 fake io 覆盖不到真实 readLine——真实管道路径靠服务器冒烟兜底。
-4. **scrypt maxmem 必须显式**：N=2¹⁵ 即超默认 32 MiB maxmem 抛 RangeError（本机实测）；
-   N=2¹⁶/r=8 需要显式 `maxmem: 128 MiB`。单次派生 ~150 ms。
-5. **`$` 在 `String.replace` replacement 里是捕获组语法**：`"$16384$"` 里的 `$1` 会被替换成
-   空串——测试里改哈希参数段用 `split("$")`/`join("$")` 或构造新串，别用 replace。
-6. **scrypt 的 N 参与派生**：改 stored 串的 N 段而不重派生 → 验证必失败。规格 §5 测试项 6
-   的"替换 N 段"写法是错的，已修正为"构造旧参数哈希"（`impl-m3.md` 有注）。
-7. **lint 行数陷阱再确认**：`max-lines` 250 是 skipBlankLines+skipComments 计数；测试文件
-   helpers（MemTable/makeRes/harness 等 ~150 行）复制到每文件后，大套件**必须按 describe
-   拆文件**（`password-endpoints` 系列因此拆成 5 个、integration 拆成 2 个）。`max-lines-per-function`
-   把 describe 回调整体当函数计（80 行）——**单 describe 内用例总数超 80 非空行就报**。
-8. **测试文件不得互相 import**：vitest 会把 import 的 `.test.ts` 当测试执行（describe 重复
-   注册）；helpers 复制进各文件（M2 先例），不要建 src 内 helper 文件（会被 tsc 编进 lib/、
-   进 coverage 统计）。
-9. **`vi.mock` 是文件级**：mock 了 `registerPasswordEndpoints` 的文件里无法断言真实端点注册
-   ——把"端点注册"断言放集成测试（`index.password.test.ts` 只断言 gate 类型 + usersPath deps）。
-10. **fake ctx 的 effect 语义**（M1 教训重演）：callback 同步执行**并返回 disposer**，disposer
-    只收集不执行——立即执行 disposer 会把守卫 unwrap 掉，自检 fail loud。
-11. **fetch 集成测试的 body**：POST login 用例必须给 body（`makeReq` 的 asyncIterator 只在
-    body 定义时 yield），否则 username 为空 → 走 DUMMY_HASH 路径 401（看起来像产品 bug）。
+1. **`deps.verify` argument order** (must-read; only integration tests expose it): `PasswordLoginDeps.verify` must
+   have the **same signature `(password, storedHash)` as `verifyPassword`**. TS structural compatibility does not
+   check parameter names — if you swap them, unit tests (fake verify) are all green while the **real path is
+   always 401** (verifyPassword fails to parse the segment count, treating the hash string as a password).
+   This session actually hit this; it is annotated in `impl-m3.md` §4.7.
+2. **Effect callbacks must not wrap the function in another layer** (must-read; the root cause of all integration
+   tests returning 404): inside `ctx.effect(() => mountAuthEndpoints(...))`, mountAuthEndpoints must **register
+   immediately and return a merged disposer**; if it returns `() => registerX(...)`, cordis stores that function as
+   the disposer — the registration never happens, all `/auth/*` routes are always 404, and **unit tests (fake ctx
+   synchronous effect) and integration tests behave differently**, which sent debugging the long way around.
+   This is written into the `mountAuthEndpoints` JSDoc.
+3. **CLI readLine race** (only exposed by server smoke): `createInterface`'s `once("line")`/`once("close")` — when
+   "piped data arrives before createInterface and then EOF", close may fire before line → readLine returns empty
+   string → CLI reports `empty password` (**also reproduces on a local pipe**; `node -e` unit tests cannot
+   reproduce it because there is no preceding await).
+   Fix: use readline's **async iterator** (`for await (const line of lines) return line`).
+   `cli.test.ts`'s fake io does not cover the real readLine — the real pipeline path is covered by server smoke.
+4. **scrypt maxmem must be explicit**: N=2¹⁵ already exceeds the default 32 MiB maxmem and throws RangeError
+   (reproduced locally); N=2¹⁶/r=8 needs explicit `maxmem: 128 MiB`. A single derivation takes ~150 ms.
+5. **`$` is capture-group syntax in `String.replace` replacements**: the `$1` in `"$16384$"` gets replaced with an
+   empty string — when changing a hash parameter segment in tests, use `split("$")`/`join("$")` or build a new
+   string; do not use replace.
+6. **scrypt's N participates in derivation**: changing the N segment of a stored string without re-deriving →
+   verification must fail. The "replace the N segment" wording of spec §5 test item 6 is wrong and was corrected
+   to "construct a hash with old parameters" (noted in `impl-m3.md`).
+7. **Lint line-count pitfall reconfirmed**: `max-lines` 250 counts with skipBlankLines+skipComments; after copying
+   the test-file helpers (MemTable/makeRes/harness etc., ~150 lines) into every file, large suites **must be split
+   by describe across files** (the `password-endpoints` series was therefore split into 5 and integration into 2).
+   `max-lines-per-function` counts the whole describe callback as a function (80 lines) — **if the total number of
+   non-empty cases in a single describe exceeds 80, it fails**.
+8. **Test files must not import each other**: vitest executes an imported `.test.ts` as a test (describe gets
+   registered twice); copy the helpers into each file (M2 precedent), and do not create helper files inside `src/`
+   (they would be compiled into `lib/` by tsc and counted in coverage).
+9. **`vi.mock` is file-level**: in a file that mocks `registerPasswordEndpoints`, you cannot assert real endpoint
+   registration — put the "endpoint registration" assertion in integration tests (`index.password.test.ts` only
+   asserts the gate type + usersPath deps).
+10. **Fake ctx effect semantics** (M1 lesson repeated): the callback runs synchronously **and returns a disposer**,
+    and the disposer is only collected, not executed — executing the disposer immediately unwraps the guard, and
+    self-check fails loud.
+11. **fetch integration test body**: POST login cases must provide a body (`makeReq`'s asyncIterator only yields when
+    a body is defined), otherwise username is empty → goes down the DUMMY_HASH path with 401 (looks like a product bug).
 
-## 4. 服务器冒烟工作流（M3 版，已实测跑通）
+## 4. Server smoke workflow (M3 version, actually exercised end to end)
 
-在 handoff-m2 §3.2 基础上：
+On top of handoff-m2 §3.2:
 
-1. 同步 + 构建：`rsync -az --exclude node_modules --exclude .git .../dsh-auth/ ubuntu:/tmp/dsh-auth-test/`
-   → 服务器 `cd /tmp/dsh-auth-test && npm install --registry=https://registry.npmjs.org/ && npm run build`。
-2. 建用户（**真实 CLI**，本次实测 0600 正确）：
+1. Sync + build: `rsync -az --exclude node_modules --exclude .git .../dsh-auth/ ubuntu:/tmp/dsh-auth-test/`
+   → on the server `cd /tmp/dsh-auth-test && npm install --registry=https://registry.npmjs.org/ && npm run build`.
+2. Create a user (**real CLI**, 0600 verified this run):
    ```bash
    ssh ubuntu 'printf "%s\n" "<pw>" | node /tmp/dsh-auth-test/lib/cli.js user add admin --password-stdin --file ~/dsh-smoke/auth/users.yaml'
    ssh ubuntu 'node /tmp/dsh-auth-test/lib/cli.js user list --file ~/dsh-smoke/auth/users.yaml'
    ssh ubuntu 'stat -c "%a" ~/dsh-smoke/auth/users.yaml'   # 600
    ```
-3. overlay `~/dsh-smoke/cordis.patch.yml`：`dsh-auth` 行
-   `config: { mode: "password", cookieSecure: false }`（探针行已删）。
-4. 重启：kill（`pkill -f "[d]sh --profile web --port 3081"`）与启动分两个 ssh 调用；
-   **启动的 ssh 调用可能挂 2 分钟超时**（nohup 子进程 fd 让 ssh 等待）——**超时是正常的，
-   nohup 进程其实已起**，另开 ssh 检查 `pgrep` + `boot.log` 的 `dsh web:` 行即可。
-5. 验证序列（本 session 全部实测通过；TOK 提取用 `grep dsh_auth jar | awk "{print \$7}"`——
-   嵌套引号里 `$6=="..."` 会被 ssh 破坏）：
-   - `GET /auth/login` → 200 含 `name="username"`；
-   - 错口令 → 401；对 → 302 + `set-cookie`（cookieSecure=false 无 `; Secure`）；
-   - 带 cookie `/__auth_probe` → 200；无 cookie JSON → 401 / HTML → 302；
-   - `Authorization: Bearer <会话 token>` → 200；错 → 401；
-   - `/auth/status` → `{"authenticated":true}`；disabled 用户 → 401；
-   - `/auth/whatever` → 404；`DELETE /auth/login` → 405；
-   - logout → 302 + `Max-Age=0`；原 cookie → 401；
-   - WS：无凭证首行 401、cookie 101、Bearer 101；
-   - 429：**注意 IP 桶会累计前面步骤的失败**（disabled 登录也计失败）——锁定会比"连发 6 次"
-     提前出现，行为正确（5 次失败锁定、`retry-after: 30`、锁定期正确口令也 429、登录页仍 200）。
-6. 实例已停止（本 session 收尾 `pkill`）；下次使用先 `pgrep` 检查。
+3. overlay `~/dsh-smoke/cordis.patch.yml`: the `dsh-auth` line
+   `config: { mode: "password", cookieSecure: false }` (probe line already removed).
+4. Restart: kill (`pkill -f "[d]sh --profile web --port 3081"`) and start are two separate ssh calls;
+   **the ssh call that starts may hang and time out after 2 minutes** (the nohup child process fds make ssh
+   wait) — **the timeout is normal; the nohup process is actually up**. Open another ssh and check `pgrep` +
+   the `dsh web:` line in `boot.log`.
+5. Verification sequence (all actually exercised and passing this session; TOK extraction uses
+   `grep dsh_auth jar | awk "{print \$7}"` — in nested quotes `$6=="..."` gets broken by ssh):
+   - `GET /auth/login` → 200 containing `name="username"`;
+   - wrong password → 401; correct → 302 + `set-cookie` (cookieSecure=false has no `; Secure`);
+   - with cookie `/__auth_probe` → 200; without cookie JSON → 401 / HTML → 302;
+   - `Authorization: Bearer <session token>` → 200; wrong → 401;
+   - `/auth/status` → `{"authenticated":true}`; disabled user → 401;
+   - `/auth/whatever` → 404; `DELETE /auth/login` → 405;
+   - logout → 302 + `Max-Age=0`; original cookie → 401;
+   - WS: no credentials first line 401, cookie 101, Bearer 101;
+   - 429: **note the IP bucket accumulates the failures from the earlier steps** (disabled login also counts as a
+     failure) — lockout appears earlier than "6 rapid sends", which is correct behavior (locked after 5 failures,
+     `retry-after: 30`, correct password is also 429 during the lock period, login page still 200).
+6. The instance is stopped (final `pkill` at the end of this session); run `pgrep` first next time.
 
-## 5. 留给 M4 的起点提示
+## 5. Starting hints left for M4
 
-- 用户记录已含 `totpSecret` 字段（zod 解析、未使用）；M4 TOTP 两段式登录直接在
-  `password-login.ts` / `password-endpoints.ts` 上加挑战阶段。
-- 已评估未做项（`impl-m3.md` §9）：禁用用户即时吊销会话（`SessionStore` 加 `revokeBySubject`
-  或门内查用户状态——注意门内做文件 IO 的性能/缓存取舍）、CSRF token、限速持久化、
-  token+password 双模式并存。
-- 冒烟验证过的 Bearer=会话 token 语义：`GET /auth/status` 只认 cookie（M5 冻结，未变）。
-- CLI 的 readLine 已用 async iterator 修复——若 M4 加交互式输入（如 TOTP secret 生成），
-  复用同一模式。
+- The user record already contains the `totpSecret` field (zod-parsed, unused); M4's two-stage TOTP login can add
+  the challenge stage directly in `password-login.ts` / `password-endpoints.ts`.
+- Evaluated-but-not-done items (`impl-m3.md` §9): immediate revocation of sessions for disabled users (`SessionStore`
+  adds `revokeBySubject` or checks user status inside the gate — note the performance/caching tradeoff of file IO
+  inside the gate), CSRF token, rate-limit persistence, token+password dual-mode coexistence.
+- Bearer=session token semantics verified in smoke: `GET /auth/status` only accepts the cookie (frozen in M5, unchanged).
+- The CLI's readLine has been fixed with the async iterator — if M4 adds interactive input (e.g. TOTP secret
+  generation), reuse the same pattern.
 
-## 6. 开放问题 / 待定
+## 6. Open questions / pending
 
-- 部署侧交付物已完成并实测：`deploy/cordis.patch.yml`（生产 overlay 模板）+ `docs/deployment.md`
-  （部署与验收清单）——已在服务器按文档流程走通（`npm pack` → `dsh plugin --profile web add`
-  → 包名引用 overlay → 验收序列 A–H 全绿，含 `cookieSecure: true` 的 `; Secure` cookie）。
-- 无阻塞项。候选后续：M4 规格（TOTP）、GUI 登出按钮（client 半边）。
+- The deployment-side deliverable is complete and tested: `deploy/cordis.patch.yml` (production overlay template) +
+  `docs/deployment.md` (deployment and acceptance checklist) — exercised end to end on the server following the
+  documented flow (`npm pack` → `dsh plugin --profile web add` → package-name-referenced overlay → acceptance
+  sequence A–H all green, including the `; Secure` cookie with `cookieSecure: true`).
+- No blockers. Possible follow-ups: M4 spec (TOTP), GUI logout button (client half).

--- a/docs/handoff-m3_zh.md
+++ b/docs/handoff-m3_zh.md
@@ -1,0 +1,113 @@
+# dsh-auth M3 交接文档（session handoff）
+
+> 读者：在**新 session** 中执行 `docs/impl-m4.md` 的编码代理。本文件承载本 session 独有的
+> 环境事实与过程知识——仓库里没有、重新探索成本高或会踩坑的内容。
+> **阅读顺序：`AGENTS.md` → `docs/impl-m3_zh.md` → 本文档**；`docs/handoff-m2_zh.md` §3/§4 的
+> 环境事实（沙箱网络、服务器访问、pkill 技巧、lint 陷阱）依然有效，不重复。
+
+---
+
+## 1. 一句话现状
+
+M3（password 模式：users.yaml + scrypt + 限速 + `dsh-auth user` CLI）已交付：`npm run verify`
+全绿（174 测试）、lib 同批、**真实服务器端到端冒烟全部通过**（登录/会话/Bearer 会话 token/
+WS/429 限速/禁用用户/白名单）。`mode: "token"`（M2）行为零改动、回归绿。
+
+## 2. 仓库与远端状态快照（2026-08-15 下午，push 后）
+
+- 分支：`development` 已与 `origin/development` 同步（9 个提交全部推送，
+  `git log --oneline origin/development..HEAD` 为空）：
+  - M2：`c184dbc`（spec 最终化）→ `bbe39bd`（handoff 快照）→ `aee37b4`（feat 实施）→
+    `6a5064e`（lazy credentials 文档）；
+  - M3：`1fac9fe`（spec）→ `db21eac`（feat 实施）→ `e030e75`（docs 契约/handoff）→
+    `5f049c2`（handoff 快照刷新 + plan 路线图 ✅）→ `04037a9`（部署交付物）。
+- **PR #2 已开**（`development` → `main`，标题 "M2 shared token gate + M3 password login
+  flow..."）：待合并。合并后 `main` 上的 `feat:` 提交会触发 release-please 自动开 **release
+  PR**（版本 bump + CHANGELOG，见 `docs/development.md` Releases）——那是自动化流程，无需
+  手工处理；release PR 合并前不要手工改 `package.json` 版本。
+- M3 实施期间的提交纪律照旧：`lib/` 与 `src/` 同批；`docs:`/`feat:` 分型。
+
+## 3. M3 实施踩坑清单（新 session 直接规避）
+
+1. **`deps.verify` 参数顺序**（必读，集成测试才暴露）：`PasswordLoginDeps.verify` 必须与
+   `verifyPassword` **同形 `(password, storedHash)`**。TS 结构兼容不检查参数名——写反了
+   单测（fake verify）全绿、**真实路径恒 401**（verifyPassword 把哈希串当口令解析段数失败）。
+   本 session 实测踩中，已在 `impl-m3.md` §4.7 标注。
+2. **effect 回调不得再包一层函数**（必读，所有集成测试 404 的根因）：`ctx.effect(() =>
+mountAuthEndpoints(...))` 里，mountAuthEndpoints 必须**立即执行注册并返回合并 disposer**；
+   若返回 `() => registerX(...)`，cordis 会把该函数当 disposer 存起来——注册永不发生，所有
+   `/auth/*` 恒 404 且**单测（fake ctx 同步 effect）与集成测试表现不同**，定位绕了远路。
+   已写进 `mountAuthEndpoints` 的 JSDoc。
+3. **CLI readLine 竞态**（服务器冒烟才暴露）：`createInterface` 的 `once("line")`/`once("close")`
+   在"管道数据先于 createInterface 到达并 EOF"时 close 可能先于 line → readLine 返回空串 →
+   CLI 报 `empty password`（**本机管道也复现**；`node -e` 单测复现不了因为无前置 await）。
+   修复：用 readline 的 **async iterator**（`for await (const line of lines) return line`）。
+   `cli.test.ts` 的 fake io 覆盖不到真实 readLine——真实管道路径靠服务器冒烟兜底。
+4. **scrypt maxmem 必须显式**：N=2¹⁵ 即超默认 32 MiB maxmem 抛 RangeError（本机实测）；
+   N=2¹⁶/r=8 需要显式 `maxmem: 128 MiB`。单次派生 ~150 ms。
+5. **`$` 在 `String.replace` replacement 里是捕获组语法**：`"$16384$"` 里的 `$1` 会被替换成
+   空串——测试里改哈希参数段用 `split("$")`/`join("$")` 或构造新串，别用 replace。
+6. **scrypt 的 N 参与派生**：改 stored 串的 N 段而不重派生 → 验证必失败。规格 §5 测试项 6
+   的"替换 N 段"写法是错的，已修正为"构造旧参数哈希"（`impl-m3.md` 有注）。
+7. **lint 行数陷阱再确认**：`max-lines` 250 是 skipBlankLines+skipComments 计数；测试文件
+   helpers（MemTable/makeRes/harness 等 ~150 行）复制到每文件后，大套件**必须按 describe
+   拆文件**（`password-endpoints` 系列因此拆成 5 个、integration 拆成 2 个）。`max-lines-per-function`
+   把 describe 回调整体当函数计（80 行）——**单 describe 内用例总数超 80 非空行就报**。
+8. **测试文件不得互相 import**：vitest 会把 import 的 `.test.ts` 当测试执行（describe 重复
+   注册）；helpers 复制进各文件（M2 先例），不要建 src 内 helper 文件（会被 tsc 编进 lib/、
+   进 coverage 统计）。
+9. **`vi.mock` 是文件级**：mock 了 `registerPasswordEndpoints` 的文件里无法断言真实端点注册
+   ——把"端点注册"断言放集成测试（`index.password.test.ts` 只断言 gate 类型 + usersPath deps）。
+10. **fake ctx 的 effect 语义**（M1 教训重演）：callback 同步执行**并返回 disposer**，disposer
+    只收集不执行——立即执行 disposer 会把守卫 unwrap 掉，自检 fail loud。
+11. **fetch 集成测试的 body**：POST login 用例必须给 body（`makeReq` 的 asyncIterator 只在
+    body 定义时 yield），否则 username 为空 → 走 DUMMY_HASH 路径 401（看起来像产品 bug）。
+
+## 4. 服务器冒烟工作流（M3 版，已实测跑通）
+
+在 handoff-m2 §3.2 基础上：
+
+1. 同步 + 构建：`rsync -az --exclude node_modules --exclude .git .../dsh-auth/ ubuntu:/tmp/dsh-auth-test/`
+   → 服务器 `cd /tmp/dsh-auth-test && npm install --registry=https://registry.npmjs.org/ && npm run build`。
+2. 建用户（**真实 CLI**，本次实测 0600 正确）：
+   ```bash
+   ssh ubuntu 'printf "%s\n" "<pw>" | node /tmp/dsh-auth-test/lib/cli.js user add admin --password-stdin --file ~/dsh-smoke/auth/users.yaml'
+   ssh ubuntu 'node /tmp/dsh-auth-test/lib/cli.js user list --file ~/dsh-smoke/auth/users.yaml'
+   ssh ubuntu 'stat -c "%a" ~/dsh-smoke/auth/users.yaml'   # 600
+   ```
+3. overlay `~/dsh-smoke/cordis.patch.yml`：`dsh-auth` 行
+   `config: { mode: "password", cookieSecure: false }`（探针行已删）。
+4. 重启：kill（`pkill -f "[d]sh --profile web --port 3081"`）与启动分两个 ssh 调用；
+   **启动的 ssh 调用可能挂 2 分钟超时**（nohup 子进程 fd 让 ssh 等待）——**超时是正常的，
+   nohup 进程其实已起**，另开 ssh 检查 `pgrep` + `boot.log` 的 `dsh web:` 行即可。
+5. 验证序列（本 session 全部实测通过；TOK 提取用 `grep dsh_auth jar | awk "{print \$7}"`——
+   嵌套引号里 `$6=="..."` 会被 ssh 破坏）：
+   - `GET /auth/login` → 200 含 `name="username"`；
+   - 错口令 → 401；对 → 302 + `set-cookie`（cookieSecure=false 无 `; Secure`）；
+   - 带 cookie `/__auth_probe` → 200；无 cookie JSON → 401 / HTML → 302；
+   - `Authorization: Bearer <会话 token>` → 200；错 → 401；
+   - `/auth/status` → `{"authenticated":true}`；disabled 用户 → 401；
+   - `/auth/whatever` → 404；`DELETE /auth/login` → 405；
+   - logout → 302 + `Max-Age=0`；原 cookie → 401；
+   - WS：无凭证首行 401、cookie 101、Bearer 101；
+   - 429：**注意 IP 桶会累计前面步骤的失败**（disabled 登录也计失败）——锁定会比"连发 6 次"
+     提前出现，行为正确（5 次失败锁定、`retry-after: 30`、锁定期正确口令也 429、登录页仍 200）。
+6. 实例已停止（本 session 收尾 `pkill`）；下次使用先 `pgrep` 检查。
+
+## 5. 留给 M4 的起点提示
+
+- 用户记录已含 `totpSecret` 字段（zod 解析、未使用）；M4 TOTP 两段式登录直接在
+  `password-login.ts` / `password-endpoints.ts` 上加挑战阶段。
+- 已评估未做项（`impl-m3.md` §9）：禁用用户即时吊销会话（`SessionStore` 加 `revokeBySubject`
+  或门内查用户状态——注意门内做文件 IO 的性能/缓存取舍）、CSRF token、限速持久化、
+  token+password 双模式并存。
+- 冒烟验证过的 Bearer=会话 token 语义：`GET /auth/status` 只认 cookie（M5 冻结，未变）。
+- CLI 的 readLine 已用 async iterator 修复——若 M4 加交互式输入（如 TOTP secret 生成），
+  复用同一模式。
+
+## 6. 开放问题 / 待定
+
+- 部署侧交付物已完成并实测：`deploy/cordis.patch.yml`（生产 overlay 模板）+ `docs/deployment_zh.md`
+  （部署与验收清单）——已在服务器按文档流程走通（`npm pack` → `dsh plugin --profile web add`
+  → 包名引用 overlay → 验收序列 A–H 全绿，含 `cookieSecure: true` 的 `; Secure` cookie）。
+- 无阻塞项。候选后续：M4 规格（TOTP）、GUI 登出按钮（client 半边）。

--- a/docs/impl-m1.md
+++ b/docs/impl-m1.md
@@ -1,138 +1,138 @@
-# dsh-auth M1 实施规格（executable spec）
+# dsh-auth M1 Implementation Spec (executable spec)
 
-> 读者：执行实现的编码代理（预期 deepseek v4 flash）。本文档是**决策完备的规格**：
-> 所有判断点已预先关闭，执行者只做翻译，不做设计。
-> 设计依据见 `docs/dsh-auth-plan.md`；工程门禁见 `docs/development.md`；本文件是两者在
-> M1 范围内的唯一权威细则——冲突时以本文件为准。
+> Reader: the coding agent that executes the implementation (expected deepseek v4 flash). This document is a **decision-complete spec**:
+> every judgment point has already been closed in advance; the executor only translates, does not design.
+> Design rationale is in `docs/dsh-auth-plan.md`; engineering gates are in `docs/development.md`; this file is the sole
+> authoritative fine-grained ruleset of the two for the M1 scope — where they conflict, this file wins.
 >
-> 所有挂载点事实均已在 `@deepseek-ai/*@0.1.0-rc.6` / `@deepseek-ai/cordis@4.0.1`
-> 真实源码与类型声明上核实。**禁止自行探索 harness 内部实现**：需要任何未在本文件
-> 出现的事实（字段、签名、行为）时，停下并报告，不得猜测。
+> All mount-point facts have been verified against the real source and type declarations of `@deepseek-ai/*@0.1.0-rc.6` / `@deepseek-ai/cordis@4.0.1`.
+> **Do not explore the harness internal implementation on your own**: whenever you need a fact (field, signature, behavior) that does not
+> appear in this file, stop and report it; do not guess.
 
 ---
 
-## 1. 冻结决策表
+## 1. Frozen Decision Table
 
-| #   | 决策               | 冻结值                                                                                                                                                             |
-| --- | ------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| D1  | M1 门行为          | 守卫管线（包装 + 302/401/拒握手）全部实现；`gate` 为 `noopGate`（全放行）。M2 只换 gate，不动守卫                                                                  |
-| D2  | 插件依赖           | 硬依赖 `inject: ["webServer"]`；`storageDomain` 用 `ctx.get()` 软读                                                                                                |
-| D3  | storageDomain 缺失 | `ctx.logger("dsh-auth").error(...)` 后**继续挂载守卫**（M1 门是惰性的；M2 起改为运行时 deny-all fail-closed）                                                      |
-| D4  | auth 服务          | `ctx.provide("auth", { sessions, gate })`；`gate` 是可写字段（M2 换流、测试注入假门）；类型增强 `declare module "@deepseek-ai/cordis"`                             |
-| D5  | 守卫标记           | `Symbol.for("dsh-auth.guarded")` 挂在被包装 handler/方法上；重复包装幂等（已标记则原样返回）                                                                       |
-| D6  | 生命周期可逆       | `ctx.effect` 注册还原器；还原器反向执行：先撤守卫，再关 domain。还原 = 恢复快照 + 原方法                                                                           |
-| D7  | 拒绝响应           | 浏览器导航（GET 且 `Accept` 含 `text/html`）→ `302 /auth/login?next=<encoded pathname>`；其余 HTTP → `401` body `unauthorized`；两者都带 `cache-control: no-store` |
-| D8  | WS 拒绝            | 不进入 ws 协商：`socket.write("HTTP/1.1 401 Unauthorized\r\nConnection: close\r\n\r\n")` 后 `socket.destroy()`；守卫不为 socket 附加任何监听器                     |
-| D9  | 自检失败           | 逐条 `logger.error` 后 `throw new Error("dsh-auth: guard self-check failed: ...")`（fiber 启动失败 = fail loud）                                                   |
-| D10 | 会话 token         | `randomBytes(32).toString("base64url")`（43 字符，无填充）；落盘键 = `sha256` hex 小写（64 字符）；**日志永不输出完整 token**                                      |
-| D11 | 会话 TTL           | 默认 `604800` 秒（7 天），自创建起固定过期、不滑动                                                                                                                 |
-| D12 | 登出语义           | 吊销 = 删除行（`delete`）；`pruneExpired` 在每次 `create` 前全表扫描清理过期行                                                                                     |
-| D13 | Cookie             | `buildSetCookie(name, token, maxAge)` 输出精确格式 `<name>=<token>; Max-Age=<secs>; Path=/; HttpOnly; Secure; SameSite=Lax`（M2 使用，M1 冻结并测试）              |
-| D14 | Config             | schemastery（与 harness 一致）；record schema 用 zod（storage-domain 的分工约定）                                                                                  |
-| D15 | 模块系统           | NodeNext；相对导入一律 `.js` 后缀；禁 `console.*`；日志走 `ctx.logger("dsh-auth")`                                                                                 |
-| D16 | 幂等重挂           | 同一 server 第二次 `wrapServer` 返回同一 unwrap（`WeakMap` 记录），不产生双守卫                                                                                    |
-
----
-
-## 2. 权威契约（挂载点事实）
-
-### 2.1 `webServer` 服务（`@deepseek-ai/dsh-host-webserver@0.1.0-rc.6`）
-
-运行时事实（`private` 仅是 TS 层面，运行时全部可达）：
-
-- 表：`server.exact: Map<string, WebRoute>`、`server.prefixes: Map<string, WebRoute>`、
-  `server.upgrades: Map<string, WebUpgradeRoute>`；`server.fallback: handler | undefined`。
-- `WebRoute = { kind: "exact" | "prefix"; path: string; handler: (req, res) => void | Promise<void> }`；
-  `WebUpgradeRoute = { path: string; handler: (req, socket: Duplex, head: Buffer) => void | Promise<void> }`。
-- 注册方法：`register(route)`（重复 `(kind, path)` 抛错）、`registerUpgrade(route)`（重复 path 抛错）、
-  `registerFallback(handler)`（第二个抛错）。**三者都返回 disposer**，disposer 按 path 删表项——
-  原地替换表项内容不破坏已发出 disposer 的语义。
-- 分发（请求时查表）：`match(pathname)` = exact 表精确命中 → 否则最长前缀（`pathname === prefix` 或
-  `pathname.startsWith(prefix + "/")`）→ 否则 fallback → 否则 404。
-- 升级分发：`upgrade` 事件里 `this.upgrades.get(new URL(req.url ?? "/", "http://x").pathname)`，
-  未命中销毁 socket。
-- 错误处理：async handler 抛错由 webserver 统一捕获：`ctx.logger.warn` + 未发头则 400 / 已发头则 destroy。
-  守卫**不得吞掉 handler 错误**（直接向上抛，交给这条路径）。
-- 服务形态：`WebServer extends Service`，`super(ctx, "webServer")` 注册服务；`static Config` 为
-  schemastery（`host: "127.0.0.1" | "0.0.0.0"`，`port: z.natural().max(65535)`，port 0 = 系统分配）。
-  挂载后监听立即生效（`[Service.init]`），`instance.port` 是最终监听端口。
-
-### 2.2 storage domain（`@deepseek-ai/dsh-storage-domain@0.1.0-rc.6`）
-
-- 模块导出：`defineDomain(spec)`、`domainTable(zodSchema)`；`ctx.storageDomain: DomainFacility`。
-- `DomainFacility.open(spec): Promise<Domain<S>>` —— **调用者拥有返回的 handle**，必须自己在
-  effect disposer 里 `await domain.close()`（幂等）。
-- `Domain<S>`：`domain.table(name): KvTable<K, V>`（handle 稳定，可重复取）；`domain.close(): Promise<void>`。
-- `KvTable`：`get(key): V | undefined`（同步内存读）、`put(key, value): Promise<void>`、
-  `delete(key): Promise<boolean>`、`entries(): IterableIterator<[K, V]>`（快照迭代）、`size: number`。
-  写先落介质再改内存；返回的记录是存储对象本身，**不得原地修改**。
-- `DomainSpec = { name: string; version: number; global?: ...; tables: Record<string, DomainTableSpec> }`。
-  spec 的 record schema 用 **zod**（`z.infer` 派生类型，不手写重复类型）。
-- **名称约束（实测核实）**：`DomainSpec.name` 与表名都必须匹配
-  `UNIT_NAME_RE = /^[a-z][a-z0-9_]*$/`（`@deepseek-ai/dsh-storage` 导出）——**禁止连字符**，
-  否则 `defineDomain` 在模块加载时抛错。故本插件 domain 名为 `dsh_auth_sessions`（下划线）。
-- 后端：`dsh-storage-json` 以 `backend: "json"` 注册，root 下每 unit 一个 `<unit>.json` 文件；
-  文件格式（实测核实）：`{ unit: { name, version }, global, tables: { <table>: { <key>: record } } }`，
-  pretty-printed + 末尾换行。`dsh-storage-domain` 的 Config `{ backend: "json" }`（本机 web profile 已这样配置）。
-- 真实 web 组合中 `storage-domain` 行在 bundle 层（`dsh-web-app`），profile 层之后才挂我们的行，
-  因此 apply 时 `ctx.get("storageDomain")` 正常可见；集成测试中先挂 storage 栈再挂本插件。
-
-### 2.3 cordis Context（`@deepseek-ai/cordis@4.0.1`）
-
-- 对象插件形状：`{ name, inject, apply, Config }`；`inject` 声明的服务可用后 apply 才执行。
-- `ctx.get(name)` 软读；`ctx.provide(name, value)` 提供服务（随 fiber 自动注销）。
-- `ctx.effect(callback, label)`：callback 返回 disposer（同步或异步皆可），fiber 卸载时
-  **按注册逆序**执行 disposer。挂载：`ctx.plugin(plugin, ...config)` 返回 `Fiber & PromiseLike<Fiber>`，
-  `Fiber.dispose(): Promise<void>` 卸载。
-- `ctx.logger` 本身是 logger 实例；`ctx.logger("dsh-auth")` 返回命名 logger（`error/warn/info`）。
-- `new Context()` 自带内建服务（logger/registry/reflect）。
+| #   | Decision              | Frozen Value                                                                                                                                                                         |
+| --- | --------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| D1  | M1 gate behavior      | The guard pipeline (wrapping + 302/401/deny handshake) is fully implemented; `gate` is `noopGate` (allows everything). M2 only swaps the gate, does not touch the guard              |
+| D2  | Plugin dependencies   | Hard dependency `inject: ["webServer"]`; `storageDomain` is soft-read via `ctx.get()`                                                                                                |
+| D3  | storageDomain missing | `ctx.logger("dsh-auth").error(...)` then **continue mounting the guard** (the M1 gate is lazy; from M2 onward it changes to runtime deny-all fail-closed)                            |
+| D4  | auth service          | `ctx.provide("auth", { sessions, gate })`; `gate` is a writable field (M2 swaps the stream, tests inject a fake gate); type augmentation `declare module "@deepseek-ai/cordis"`      |
+| D5  | Guard marker          | `Symbol.for("dsh-auth.guarded")` is attached to the wrapped handler/method; repeated wrapping is idempotent (if marked, return as-is)                                                |
+| D6  | Reversible lifecycle  | `ctx.effect` registers the restorer; the restorer runs in reverse: first uninstall the guard, then close the domain. Restore = restore the snapshot + the original method            |
+| D7  | Deny response         | Browser navigation (GET and `Accept` contains `text/html`) → `302 /auth/login?next=<encoded pathname>`; other HTTP → `401` body `unauthorized`; both carry `cache-control: no-store` |
+| D8  | WS deny               | Do not enter ws negotiation: `socket.write("HTTP/1.1 401 Unauthorized\r\nConnection: close\r\n\r\n")` then `socket.destroy()`; the guard attaches no listeners to the socket         |
+| D9  | Self-check failure    | Per-item `logger.error` then `throw new Error("dsh-auth: guard self-check failed: ...")` (fiber start failure = fail loud)                                                           |
+| D10 | Session token         | `randomBytes(32).toString("base64url")` (43 chars, no padding); on-disk key = `sha256` hex lowercase (64 chars); **logs never output the full token**                                |
+| D11 | Session TTL           | Default `604800` seconds (7 days), fixed expiration from creation, no sliding                                                                                                        |
+| D12 | Logout semantics      | Revoke = delete the row (`delete`); `pruneExpired` scans the entire table and cleans up expired rows before every `create`                                                           |
+| D13 | Cookie                | `buildSetCookie(name, token, maxAge)` outputs the exact format `<name>=<token>; Max-Age=<secs>; Path=/; HttpOnly; Secure; SameSite=Lax` (used by M2, frozen and tested by M1)        |
+| D14 | Config                | schemastery (consistent with the harness); the record schema uses zod (the storage-domain division-of-labor convention)                                                              |
+| D15 | Module system         | NodeNext; relative imports always use the `.js` suffix; `console.*` forbidden; logging goes through `ctx.logger("dsh-auth")`                                                         |
+| D16 | Idempotent re-wrap    | A second `wrapServer` on the same server returns the same unwrap (recorded via `WeakMap`), no double guard                                                                           |
 
 ---
 
-## 3. 依赖变更（`package.json`）
+## 2. Authoritative Contracts (Mount-Point Facts)
+
+### 2.1 `webServer` service (`@deepseek-ai/dsh-host-webserver@0.1.0-rc.6`)
+
+Runtime facts (`private` is only a TS-level concern; everything is reachable at runtime):
+
+- Tables: `server.exact: Map<string, WebRoute>`, `server.prefixes: Map<string, WebRoute>`,
+  `server.upgrades: Map<string, WebUpgradeRoute>`; `server.fallback: handler | undefined`.
+- `WebRoute = { kind: "exact" | "prefix"; path: string; handler: (req, res) => void | Promise<void> }`;
+  `WebUpgradeRoute = { path: string; handler: (req, socket: Duplex, head: Buffer) => void | Promise<void> }`.
+- Registration methods: `register(route)` (throws on duplicate `(kind, path)`), `registerUpgrade(route)` (throws on duplicate path),
+  `registerFallback(handler)` (the second one throws). **All three return disposers**, and the disposer deletes the table entry by path —
+  replacing a table entry in place does not break the semantics of disposers already emitted.
+- Dispatch (table lookup at request time): `match(pathname)` = exact hit in the exact table → otherwise longest prefix (`pathname === prefix` or
+  `pathname.startsWith(prefix + "/")`) → otherwise fallback → otherwise 404.
+- Upgrade dispatch: in the `upgrade` event, `this.upgrades.get(new URL(req.url ?? "/", "http://x").pathname)`,
+  destroy the socket on a miss.
+- Error handling: errors thrown by async handlers are caught uniformly by the webserver: `ctx.logger.warn` + 400 if headers not sent / destroy if already sent.
+  The guard **must not swallow handler errors** (throw them upward directly, let them take this path).
+- Service shape: `WebServer extends Service`, registered via `super(ctx, "webServer")`; `static Config` is
+  schemastery (`host: "127.0.0.1" | "0.0.0.0"`, `port: z.natural().max(65535)`, port 0 = OS-assigned).
+  The listen takes effect immediately on mount (`[Service.init]`), and `instance.port` is the final listening port.
+
+### 2.2 storage domain (`@deepseek-ai/dsh-storage-domain@0.1.0-rc.6`)
+
+- Module exports: `defineDomain(spec)`, `domainTable(zodSchema)`; `ctx.storageDomain: DomainFacility`.
+- `DomainFacility.open(spec): Promise<Domain<S>>` — **the caller owns the returned handle** and must itself
+  `await domain.close()` in the effect disposer (idempotent).
+- `Domain<S>`: `domain.table(name): KvTable<K, V>` (the handle is stable, can be fetched repeatedly); `domain.close(): Promise<void>`.
+- `KvTable`: `get(key): V | undefined` (synchronous in-memory read), `put(key, value): Promise<void>`,
+  `delete(key): Promise<boolean>`, `entries(): IterableIterator<[K, V]>` (snapshot iteration), `size: number`.
+  Writes persist to the medium first, then mutate memory; the returned record is the stored object itself and **must not be mutated in place**.
+- `DomainSpec = { name: string; version: number; global?: ...; tables: Record<string, DomainTableSpec> }`.
+  The spec's record schema uses **zod** (`z.infer` derives the type; do not hand-write a duplicate type).
+- **Name constraint (verified by measurement)**: `DomainSpec.name` and the table name must both match
+  `UNIT_NAME_RE = /^[a-z][a-z0-9_]*$/` (exported by `@deepseek-ai/dsh-storage`) — **hyphens forbidden**,
+  otherwise `defineDomain` throws at module load time. Hence this plugin's domain name is `dsh_auth_sessions` (underscores).
+- Backend: `dsh-storage-json` registers with `backend: "json"`, one `<unit>.json` file per unit under root;
+  file format (verified by measurement): `{ unit: { name, version }, global, tables: { <table>: { <key>: record } } }`,
+  pretty-printed + trailing newline. `dsh-storage-domain`'s Config is `{ backend: "json" }` (the local web profile is already configured this way).
+- In the real web composition, the `storage-domain` line is at the bundle layer (`dsh-web-app`), and our line is mounted only after the profile layer,
+  so `ctx.get("storageDomain")` is normally visible at apply time; in integration tests, mount the storage stack first, then this plugin.
+
+### 2.3 cordis Context (`@deepseek-ai/cordis@4.0.1`)
+
+- Object plugin shape: `{ name, inject, apply, Config }`; apply only executes after the services declared by `inject` are available.
+- `ctx.get(name)` is a soft read; `ctx.provide(name, value)` provides a service (automatically unregistered with the fiber).
+- `ctx.effect(callback, label)`: callback returns a disposer (sync or async), and on fiber unload the disposers
+  execute **in reverse registration order**. Mounting: `ctx.plugin(plugin, ...config)` returns `Fiber & PromiseLike<Fiber>`,
+  `Fiber.dispose(): Promise<void>` uninstalls.
+- `ctx.logger` itself is a logger instance; `ctx.logger("dsh-auth")` returns a named logger (`error/warn/info`).
+- `new Context()` ships with built-in services (logger/registry/reflect).
+
+---
+
+## 3. Dependency Changes (`package.json`)
 
 ```jsonc
 {
   "dependencies": {
-    "@deepseek-ai/dsh-storage-domain": "^0.1.0-rc.6", // 新增：src 运行时 import（defineDomain/domainTable）
-    "@deepseek-ai/schemastery": "^3.18.1", // 已有
-    "zod": "^4.4.3", // 已有
+    "@deepseek-ai/dsh-storage-domain": "^0.1.0-rc.6", // new: src runtime import (defineDomain/domainTable)
+    "@deepseek-ai/schemastery": "^3.18.1", // existing
+    "zod": "^4.4.3", // existing
   },
   "peerDependencies": {
-    "@deepseek-ai/cordis": "^4.0.1", // 从 dependencies 移入（宿主提供实例）
+    "@deepseek-ai/cordis": "^4.0.1", // moved out of dependencies (the host provides the instance)
   },
   "devDependencies": {
-    // 新增（仅测试/类型）：
+    // new (test/type only):
     "@deepseek-ai/cordis": "^4.0.1",
     "@deepseek-ai/dsh-host-webserver": "^0.1.0-rc.6",
     "@deepseek-ai/dsh-storage": "^0.1.0-rc.6",
     "@deepseek-ai/dsh-storage-json": "^0.1.0-rc.6",
-    // 其余保持不动
+    // the rest stays unchanged
   },
 }
 ```
 
-- 安装必须 `npm install --registry=https://registry.npmjs.org/`（AGENTS.md 锁仓规则；全部包已在
-  公共 npm 核实存在，版本精确）。
-- src 中**不得** import `dsh-host-webserver`/`dsh-storage`/`dsh-storage-json`（它们只出现在测试里）；
-  src 对 webserver 用自定义结构类型（§4.2）。
+- The install must use `npm install --registry=https://registry.npmjs.org/` (AGENTS.md lockfile rule; all packages have been
+  verified to exist on the public npm, versions exact).
+- src **must not** import `dsh-host-webserver`/`dsh-storage`/`dsh-storage-json` (they appear only in tests);
+  src uses custom structural types for the webserver (§4.2).
 
 ---
 
-## 4. 文件蓝图
+## 4. File Blueprints
 
-每个文件：职责、导出签名、行为约定、长度预算（文件 ≤250 行、函数 ≤80 行、复杂度 ≤15，均为
-ESLint error，违反即红）。
+Each file: responsibility, exported signatures, behavior conventions, line budget (file ≤250 lines, function ≤80 lines, complexity ≤15; all
+ESLint errors, violating any of them is red).
 
-### 4.1 `src/gate.ts` —— 门决策词表与惰性门
+### 4.1 `src/gate.ts` — gate decision vocabulary and lazy gate
 
 ```ts
 import type { IncomingMessage } from "node:http";
 
-/** Guard 判定时报告的被包装入口类别。 */
+/** The wrapped-entry category reported during a Guard decision. */
 export type GuardKind = "exact" | "prefix" | "upgrade" | "fallback";
 
-/** allow = 放行原 handler；deny = 由守卫执行 302/401/拒握手（§D7/D8）。 */
+/** allow = let the original handler through; deny = the guard executes the 302/401/deny handshake (§D7/D8). */
 export type GateDecision = "allow" | "deny";
 
 export interface Gate {
@@ -143,13 +143,13 @@ export interface Gate {
   ): GateDecision | Promise<GateDecision>;
 }
 
-/** M1 惰性门：恒放行。M2 用 token/密码门整体替换。 */
+/** M1 lazy gate: always allows. M2 replaces it wholesale with the token/password gate. */
 export const noopGate: Gate = { decide: () => "allow" };
 ```
 
-行为约定：`GuardKind` 定义在此处（`guard.ts` 依赖它，方向单向，无循环 import）。
+Behavior convention: `GuardKind` is defined here (`guard.ts` depends on it, direction is one-way, no circular import).
 
-### 4.2 `src/guard.ts` —— 包装机制与拒绝管线（核心风险文件）
+### 4.2 `src/guard.ts` — wrapping mechanism and deny pipeline (core risk file)
 
 ```ts
 import type { IncomingMessage, ServerResponse } from "node:http";
@@ -176,7 +176,7 @@ export interface WrappableUpgradeRoute {
   handler: UpgradeHandler;
 }
 
-/** webServer 运行时形状的结构镜像（§2.1）；真实实例运行时满足它。 */
+/** Structural mirror of the webServer runtime shape (§2.1); the real instance satisfies it at runtime. */
 export interface WrappableServer {
   exact: Map<string, WrappableRoute>;
   prefixes: Map<string, WrappableRoute>;
@@ -189,8 +189,8 @@ export interface WrappableServer {
 
 export type GuardLog = { error(message: unknown): void };
 
-// 签名说明：`Function` 被 lint（no-unsafe-function-type）禁用，用任意函数形
-// 式 `(...args: never[]) => unknown` 表达"接受任意 callable"。
+// Signature note: `Function` is banned by lint (no-unsafe-function-type); the arbitrary-function
+// form `(...args: never[]) => unknown` expresses "accept any callable".
 export function isGuarded(target: (...args: never[]) => unknown): boolean;
 export function guardHttp(gate: () => Gate, kind: GuardKind, handler: HttpHandler): HttpHandler;
 export function guardUpgrade(gate: () => Gate, handler: UpgradeHandler): UpgradeHandler;
@@ -199,35 +199,35 @@ export function denyUpgrade(socket: Duplex): void;
 export function wrapServer(server: WrappableServer, gate: () => Gate, log: GuardLog): () => void;
 ```
 
-实现约定（逐条执行，不得偏离）：
+Implementation conventions (execute each of these, no deviation):
 
-- `guardHttp`：若 `handler[GUARDED] === true` 原样返回（D5 幂等）。否则返回标记过的
-  `async (req, res) => { const pathname = new URL(req.url ?? "/", "http://x").pathname; const d = await gate().decide(req, kind, pathname); if (d === "allow") { await handler(req, res); return; } denyHttp(req, res); }`。
-  错误不捕获（§2.1 webserver 统一处理）。
-- `guardUpgrade`：同构；deny 分支调 `denyUpgrade(socket)`，不调原 handler，不附加 socket 监听器。
-- `denyHttp`：`res.setHeader("cache-control", "no-store")`；`req.method === "GET"` 且
-  `String(req.headers.accept ?? "").includes("text/html")` → `res.writeHead(302, { location: `${LOGIN_PATH}?next=${encodeURIComponent(pathname)}` }); res.end();`；
-  否则 `res.writeHead(401, { "content-type": "text/plain" }); res.end("unauthorized");`。
-  header 名用小写（node 规范化为小写）。
-- `denyUpgrade`：先 `socket.write("HTTP/1.1 401 Unauthorized\r\nConnection: close\r\n\r\n")` 再
-  `socket.destroy()`。
-- `wrapServer`：
-  1. 模块级 `const unwrappers = new WeakMap<WrappableServer, () => void>()`；已存在则返回既有 unwrap（D16）。
-  2. 捕获 `orig = { register: server.register.bind(server), registerUpgrade: ..., registerFallback: ... }`
-     与快照 `{ exact: new Map(server.exact), prefixes: ..., upgrades: ..., fallback: server.fallback }`。
-  3. 原地替换存量：`for (const [p, r] of server.exact) server.exact.set(p, { ...r, handler: guardHttp(gate, "exact", r.handler) })`；
-     prefixes 同理（kind 用 `r.kind`）；upgrades 用 `guardUpgrade`；`fallback` 存在则
-     `server.fallback = guardHttp(gate, "fallback", server.fallback)`。
-  4. 替换实例方法（增量保险，apply 顺序无关）：
-     `server.register = (route) => orig.register({ ...route, handler: guardHttp(gate, route.kind, route.handler) })`；
-     `registerUpgrade` 用 `guardUpgrade`；`registerFallback = (h) => orig.registerFallback(guardHttp(gate, "fallback", h))`。
-     三个替换后的函数都置 `[GUARDED] = true`（自检用，§4.4）。
-  5. 返回 unwrap（并存入 WeakMap）：清空四个表并按快照回填（`server.exact.clear()` 后逐个 set 快照项）、
-     `server.fallback = snapshot.fallback`、三个方法还原为 `orig.*`。post-wrap 期间新增的注册随还原丢弃
-     （disposer 仍按 path 操作当前表，语义安全——还原即整体回滚）。
-- `gate: () => Gate` 是访问器而非值：闭包每次请求读最新门（M2 换流、测试注入假门都靠这个）。
+- `guardHttp`: if `handler[GUARDED] === true`, return as-is (D5 idempotency). Otherwise return a marked
+  `async (req, res) => { const pathname = new URL(req.url ?? "/", "http://x").pathname; const d = await gate().decide(req, kind, pathname); if (d === "allow") { await handler(req, res); return; } denyHttp(req, res); }`.
+  Errors are not caught (§2.1 the webserver handles them uniformly).
+- `guardUpgrade`: isomorphic; the deny branch calls `denyUpgrade(socket)`, does not call the original handler, attaches no socket listeners.
+- `denyHttp`: `res.setHeader("cache-control", "no-store")`; `req.method === "GET"` and
+  `String(req.headers.accept ?? "").includes("text/html")` → `res.writeHead(302, { location: `${LOGIN_PATH}?next=${encodeURIComponent(pathname)}` }); res.end();`;
+  otherwise `res.writeHead(401, { "content-type": "text/plain" }); res.end("unauthorized");`.
+  Header names are lowercase (node normalizes to lowercase).
+- `denyUpgrade`: first `socket.write("HTTP/1.1 401 Unauthorized\r\nConnection: close\r\n\r\n")` then
+  `socket.destroy()`.
+- `wrapServer`:
+  1. A module-level `const unwrappers = new WeakMap<WrappableServer, () => void>()`; if it already exists, return the existing unwrap (D16).
+  2. Capture `orig = { register: server.register.bind(server), registerUpgrade: ..., registerFallback: ... }`
+     and the snapshot `{ exact: new Map(server.exact), prefixes: ..., upgrades: ..., fallback: server.fallback }`.
+  3. Replace the existing entries in place: `for (const [p, r] of server.exact) server.exact.set(p, { ...r, handler: guardHttp(gate, "exact", r.handler) })`;
+     same for prefixes (kind uses `r.kind`); upgrades use `guardUpgrade`; if `fallback` exists,
+     `server.fallback = guardHttp(gate, "fallback", server.fallback)`.
+  4. Replace the instance methods (incremental insurance, apply-order-independent):
+     `server.register = (route) => orig.register({ ...route, handler: guardHttp(gate, route.kind, route.handler) })`;
+     `registerUpgrade` uses `guardUpgrade`; `registerFallback = (h) => orig.registerFallback(guardHttp(gate, "fallback", h))`.
+     All three replaced functions set `[GUARDED] = true` (for self-check, §4.4).
+  5. Return the unwrap (and store it in the WeakMap): clear the four tables and refill from the snapshot (`server.exact.clear()` then set each snapshot entry one by one),
+     `server.fallback = snapshot.fallback`, restore the three methods to `orig.*`. Registrations added during the post-wrap period are discarded on restore
+     (disposers still operate on the current table by path, so semantics are safe — restore is an overall rollback).
+- `gate: () => Gate` is an accessor rather than a value: the closure reads the latest gate on each request (M2 swaps the stream and tests inject a fake gate, both relying on this).
 
-### 4.3 `src/session-store.ts` —— 持久化会话（storage domain）
+### 4.3 `src/session-store.ts` — persistent sessions (storage domain)
 
 ```ts
 import { defineDomain, domainTable, type KvTable } from "@deepseek-ai/dsh-storage-domain";
@@ -237,12 +237,12 @@ import { z } from "zod";
 export const COOKIE_FLAGS = "Path=/; HttpOnly; Secure; SameSite=Lax";
 
 export function buildSetCookie(cookieName: string, token: string, maxAgeSeconds: number): string;
-// 精确输出：`${cookieName}=${token}; Max-Age=${maxAgeSeconds}; ${COOKIE_FLAGS}`
+// Exact output: `${cookieName}=${token}; Max-Age=${maxAgeSeconds}; ${COOKIE_FLAGS}`
 
 export function digestToken(token: string): string; // createHash("sha256").update(token).digest("hex")
 
 export interface Session {
-  subject: string; // 审计用：产生该会话的凭证身份（M1 恒 "token"，M2 为用户名）
+  subject: string; // for audit: the credential identity that produced this session (M1 is always "token", M2 is the username)
   createdAt: number; // epoch ms
   expiresAt: number; // epoch ms
   revoked: boolean;
@@ -259,10 +259,10 @@ const sessionRowSchema = z.object({
   expiresAt: z.number().int().nonnegative(),
   revoked: z.boolean(),
 });
-// 键 = digest（64 位 hex 小写），不进 row；row 只存以上四字段。
+// key = digest (64-char hex lowercase), not stored in the row; the row stores only the four fields above.
 
 export const sessionDomainSpec = defineDomain({
-  name: "dsh_auth_sessions", // 必须匹配 UNIT_NAME_RE（无连字符，见 §2.2）
+  name: "dsh_auth_sessions", // must match UNIT_NAME_RE (no hyphens, see §2.2)
   version: 0,
   tables: { sessions: domainTable(sessionRowSchema) },
 });
@@ -270,35 +270,35 @@ export const sessionDomainSpec = defineDomain({
 export class SessionStore {
   constructor(table: KvTable<string, Session>);
   create(subject: string, ttlMs: number): Promise<IssuedSession>;
-  getByToken(token: string): Session | undefined; // 同步：哈希 → 内存读 → 校验
-  revokeByToken(token: string): Promise<boolean>; // delete 的返回值直传
-  pruneExpired(now?: number): Promise<number>; // 删全部过期行，返回删除数
+  getByToken(token: string): Session | undefined; // synchronous: hash → memory read → validate
+  revokeByToken(token: string): Promise<boolean>; // the return value of delete passed through directly
+  pruneExpired(now?: number): Promise<number>; // delete all expired rows, return the number deleted
 }
 ```
 
-行为约定：
+Behavior conventions:
 
-- `create`：先 `await this.pruneExpired()`；`token = randomBytes(32).toString("base64url")`；
-  `now = Date.now()`；`put(digest, { subject, createdAt: now, expiresAt: now + ttlMs, revoked: false })`；
-  返回 `{ token, session: 同 row }`。
-- `getByToken`：`const row = table.get(digestToken(token))`；`row === undefined || row.revoked || row.expiresAt <= Date.now()` → `undefined`；否则返回 row（**不修改 row**）。
-- `pruneExpired(now = Date.now())`：`entries()` 遍历，`expiresAt <= now` 的 `await table.delete(key)`，返回计数。
-- 本模块**不**负责 domain 的 open/close（那是 `index.ts` 的接线职责）；类对 `KvTable` 编程，
-  单测用内存假表，集成测试用真栈。
+- `create`: first `await this.pruneExpired()`; `token = randomBytes(32).toString("base64url")`;
+  `now = Date.now()`; `put(digest, { subject, createdAt: now, expiresAt: now + ttlMs, revoked: false })`;
+  returns `{ token, session: the same row }`.
+- `getByToken`: `const row = table.get(digestToken(token))`; `row === undefined || row.revoked || row.expiresAt <= Date.now()` → `undefined`; otherwise return the row (**do not modify the row**).
+- `pruneExpired(now = Date.now())`: iterate `entries()`, `await table.delete(key)` for everything with `expiresAt <= now`, return the count.
+- This module does **not** open/close the domain (that is `index.ts`'s wiring responsibility); the class programs against `KvTable`,
+  unit tests use an in-memory fake table, integration tests use the real stack.
 
-### 4.4 `src/self-check.ts` —— 启动自检
+### 4.4 `src/self-check.ts` — startup self-check
 
 ```ts
 import type { WrappableServer } from "./guard.js";
 
-/** 返回未被守卫标记覆盖的入口清单，形如 "exact /api"、"fallback"、"method register"。空 = 通过。 */
+/** Returns the list of entries not covered by the guard marker, shaped like "exact /api", "fallback", "method register". Empty = passed. */
 export function assertGuarded(server: WrappableServer): string[];
 ```
 
-行为约定：逐一检查四表全部 handler、`fallback`、以及三个注册方法（替换后的方法带 `[GUARDED]` 标记），
-未标记的条目入列。此文件**只报告，不修复、不抛错**（抛错由 `index.ts` 决定）。
+Behavior conventions: check every handler in all four tables, `fallback`, and the three registration methods (the replaced methods carry the `[GUARDED]` marker) one by one;
+add unmarked entries to the list. This file **only reports; it does not fix or throw** (throwing is decided by `index.ts`).
 
-### 4.5 `src/index.ts` —— 插件入口与接线
+### 4.5 `src/index.ts` — plugin entry and wiring
 
 ```ts
 import type { Context } from "@deepseek-ai/cordis";
@@ -313,9 +313,9 @@ export const name = "dsh-auth";
 export const inject = ["webServer"] as const;
 
 export interface AuthConfig {
-  mode: "token" | "password"; // M1 只进 schema；token 门 M2 生效
-  sessionTtl: number;          // 秒；默认 604800（7 天）
-  cookieName: string;          // 默认 "dsh_auth"
+  mode: "token" | "password"; // M1 only enters the schema; the token gate takes effect in M2
+  sessionTtl: number;          // seconds; default 604800 (7 days)
+  cookieName: string;          // default "dsh_auth"
 }
 
 export const Config: z<AuthConfig> = z.object({
@@ -325,8 +325,8 @@ export const Config: z<AuthConfig> = z.object({
 });
 
 export interface AuthService {
-  sessions: SessionStore | undefined; // storageDomain 缺失时为 undefined（D3）
-  gate: Gate;                         // 可写：M2 换流、测试注入假门
+  sessions: SessionStore | undefined; // undefined when storageDomain is missing (D3)
+  gate: Gate;                         // writable: M2 swaps the stream, tests inject a fake gate
 }
 
 declare module "@deepseek-ai/cordis" {
@@ -336,74 +336,72 @@ declare module "@deepseek-ai/cordis" {
 export function apply(ctx: Context, config: AuthConfig): void { ... }
 ```
 
-`apply` 接线骨架（照此实现，勿改顺序）：
+`apply` wiring skeleton (implement per this, don't change the order):
 
-1. `const server = ctx.get("webServer") as unknown as WrappableServer | undefined;` 为 `undefined` 则 `return`（inject 已保证存在，防御性短路）。
+1. `const server = ctx.get("webServer") as unknown as WrappableServer | undefined;` if `undefined`, `return` (inject already guarantees existence; defensive short-circuit).
 2. `const log = ctx.logger("dsh-auth");`
 3. `const auth: AuthService = { sessions: undefined, gate: noopGate }; ctx.provide("auth", auth);`
-4. 会话层（软接 storageDomain）：
+4. Session layer (soft-connect storageDomain):
    `const storageDomain = ctx.get("storageDomain") as unknown as DomainFacility | undefined;`
-   - 缺失：`log.error("storage-domain is unavailable: session persistence is disabled (guards stay mounted)");`
-   - 存在：`ctx.effect(() => { let closed = false; const opening = storageDomain.open(sessionDomainSpec); const ready = opening.then((domain) => { if (closed) { void domain.close(); return; } auth.sessions = new SessionStore(domain.table("sessions")); log.info("session domain opened: dsh_auth_sessions"); }, (error: unknown) => { log.error(`session domain open failed: ${error instanceof Error ? error.message : String(error)}`); }); return async () => { closed = true; await ready.catch(() => undefined); const domain = await opening.catch(() => undefined); await domain?.close(); }; }, "dsh-auth: session domain");`
-     （注意：`ready` 挂 `.then` 后解析为 `void`，disposer 必须从**原始** `opening` promise 取 domain 来 close，否则 domain 泄漏。）
-5. 守卫：`const unwrap = wrapServer(server, () => auth.gate, log); ctx.effect(() => unwrap, "dsh-auth: guard unwrap");`
-   （effect 逆序注销保证：先撤守卫，后关 domain。）
-6. 自检：`const failures = assertGuarded(server); if (failures.length > 0) { for (const f of failures) log.error("unwrapped entry: " + f); throw new Error("dsh-auth: guard self-check failed: " + failures.join(", ")); }`
+   - Missing: `log.error("storage-domain is unavailable: session persistence is disabled (guards stay mounted)");`
+   - Present: `ctx.effect(() => { let closed = false; const opening = storageDomain.open(sessionDomainSpec); const ready = opening.then((domain) => { if (closed) { void domain.close(); return; } auth.sessions = new SessionStore(domain.table("sessions")); log.info("session domain opened: dsh_auth_sessions"); }, (error: unknown) => { log.error(`session domain open failed: ${error instanceof Error ? error.message : String(error)}`); }); return async () => { closed = true; await ready.catch(() => undefined); const domain = await opening.catch(() => undefined); await domain?.close(); }; }, "dsh-auth: session domain");`
+     (note: `ready` resolves to `void` after `.then` is attached; the disposer must take the domain from the **original** `opening` promise to close it, otherwise the domain leaks.)
+5. Guard: `const unwrap = wrapServer(server, () => auth.gate, log); ctx.effect(() => unwrap, "dsh-auth: guard unwrap");`
+   (the effect's reverse-registration unload guarantees: uninstall the guard first, then close the domain.)
+6. Self-check: `const failures = assertGuarded(server); if (failures.length > 0) { for (const f of failures) log.error("unwrapped entry: " + f); throw new Error("dsh-auth: guard self-check failed: " + failures.join(", ")); }`
 
-其他约定：不记录/输出 config 中的任何敏感值（M1 的 config 无敏感值，但日志只打事件名与路径，不打 token）。`AuthService`/`AuthConfig` 导出的类型只引用自身定义与 `SessionStore`/`Gate`（自包类型），不泄漏 storage-domain/webserver 包类型到公开 d.ts。
+Other conventions: do not log/output any sensitive value in the config (M1's config has no sensitive values, but the logs only print event names and paths, never tokens). The exported `AuthService`/`AuthConfig` types reference only their own definitions and `SessionStore`/`Gate` (self-contained types), not leaking storage-domain/webserver package types into the public d.ts.
 
 ---
 
-## 5. 测试矩阵
+## 5. Test Matrix
 
-全部用 Vitest，显式 import（`import { describe, expect, it, beforeAll, afterAll } from "vitest"`），
-环境 node。既有 `src/index.test.ts` **整体重写**为下述用例。覆盖率红线 80%（branches/functions/
-lines/statements）照常适用。
+All tests use Vitest with explicit imports (`import { describe, expect, it, beforeAll, afterAll } from "vitest"`),
+environment node. The existing `src/index.test.ts` is **rewritten wholesale** into the cases below. The coverage red line of 80% (branches/functions/
+lines/statements) applies as usual.
 
-### 5.1 单元测试
+### 5.1 Unit Tests
 
-**`src/gate.test.ts`** — `noopGate.decide` 对任意参数返回 `"allow"`（1 个用例）。
+**`src/gate.test.ts`** — `noopGate.decide` returns `"allow"` for arbitrary arguments (1 case).
 
-**`src/guard.test.ts`** — 本文件内定义 `makeFakeServer(): WrappableServer`（Map 表 + 记录调用次数的
-register/registerUpgrade/registerFallback，返回删除用 disposer），假 `req/res/socket` 为最小对象
-（`res: { headersSent, setHeader, writeHead, end }`、`socket: { write, destroy }` 记录调用）。用例：
+**`src/guard.test.ts`** — define `makeFakeServer(): WrappableServer` inside this file (Map tables + register/registerUpgrade/registerFallback that count invocations, returning disposal disposers); fake `req/res/socket` are minimal objects
+(`res: { headersSent, setHeader, writeHead, end }`, `socket: { write, destroy }` recording calls). Cases:
 
-1. 存量包装：四表 + fallback 的 handler 均被替换（引用不等）且 `isGuarded` 为真；allow 时原 handler 以原参数被调用。
-2. 增量包装：wrap 之后 `server.register(route)` 注册的 handler 带守卫；deny 时原 handler 不被调用且收到 401。
-3. 幂等：`wrapServer` 调两次，handler 只包一层（第二次返回同一 unwrap）；unwrap 后四表/方法/fallback 与包装前逐引用相等。
-4. 拒绝-HTTP：`GET` + `Accept: text/html` → `writeHead(302)` 且 `location === "/auth/login?next=%2Fsome%2Fpath"`、`cache-control: no-store`；非导航（`Accept: application/json` 或 `POST`）→ `writeHead(401)`、body `unauthorized`。
-5. 拒绝-升级：deny → `socket.write` 收到以 `HTTP/1.1 401 Unauthorized` 开头的内容、`socket.destroy` 被调、原 handler 未被调；allow → 原 handler 收到 `(req, socket, head)`。
-6. 错误传播：原 handler reject 时守卫不捕获（`await expect(...).rejects.toThrow`）。
-7. gate 访问器：先 deny 门 → 401；把门换成 allow → 200 路径（证明运行时换门生效）。
+1. Existing-entry wrapping: the handlers of all four tables + fallback are all replaced (references unequal) and `isGuarded` is true; on allow the original handler is invoked with the original arguments.
+2. Incremental wrapping: after wrap, a handler registered by `server.register(route)` carries the guard; on deny the original handler is not invoked and a 401 is received.
+3. Idempotency: call `wrapServer` twice, the handler is wrapped only one layer (the second call returns the same unwrap); after unwrap, the four tables/methods/fallback are reference-equal to before wrapping.
+4. Deny-HTTP: `GET` + `Accept: text/html` → `writeHead(302)` and `location === "/auth/login?next=%2Fsome%2Fpath"`, `cache-control: no-store`; non-navigation (`Accept: application/json` or `POST`) → `writeHead(401)`, body `unauthorized`.
+5. Deny-upgrade: deny → `socket.write` receives content starting with `HTTP/1.1 401 Unauthorized`, `socket.destroy` is called, the original handler is not called; allow → the original handler receives `(req, socket, head)`.
+6. Error propagation: when the original handler rejects, the guard does not catch it (`await expect(...).rejects.toThrow`).
+7. Gate accessor: deny gate first → 401; swap the gate to allow → the 200 path (proves the swap of the gate at runtime takes effect).
 
-**`src/session-store.test.ts`** — 文件内 `class MemTable implements KvTable<string, Session>`（Map 实现）。
-用例：
+**`src/session-store.test.ts`** — `class MemTable implements KvTable<string, Session>` inside the file (Map implementation). Cases:
 
-1. `digestToken` 已知向量：`digestToken("abc") === "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad"`。
-2. `create`：token 匹配 `/^[A-Za-z0-9_-]{43}$/`；行已 `put`，键 = digest，`createdAt/expiresAt` 差值 = ttlMs，`revoked === false`，`subject` 透传。
-3. `getByToken`：有效 token → 返回行；未知 token → `undefined`；已过期（`expiresAt <= Date.now()`）→ `undefined`；`revoked: true` → `undefined`。
-4. `revokeByToken`：存在 → `true` 且行删除；不存在 → `false`。
-5. `pruneExpired`：混合有效/过期行，只删过期、返回精确计数、有效行原样保留。
-6. `buildSetCookie` 精确串：`buildSetCookie("dsh_auth", "tok", 604800) === "dsh_auth=tok; Max-Age=604800; Path=/; HttpOnly; Secure; SameSite=Lax"`。
+1. `digestToken` known vector: `digestToken("abc") === "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad"`.
+2. `create`: token matches `/^[A-Za-z0-9_-]{43}$/`; the row has been `put`, key = digest, `createdAt/expiresAt` difference = ttlMs, `revoked === false`, `subject` passed through.
+3. `getByToken`: valid token → returns the row; unknown token → `undefined`; expired (`expiresAt <= Date.now()`) → `undefined`; `revoked: true` → `undefined`.
+4. `revokeByToken`: exists → `true` and the row is deleted; does not exist → `false`.
+5. `pruneExpired`: mixed valid/expired rows, deletes only the expired, returns the exact count, valid rows preserved as-is.
+6. `buildSetCookie` exact string: `buildSetCookie("dsh_auth", "tok", 604800) === "dsh_auth=tok; Max-Age=604800; Path=/; HttpOnly; Secure; SameSite=Lax"`.
 
-**`src/self-check.test.ts`** — 复用 guard.test.ts 的 fake（提取到测试内共享 helper 或复制实现；**不得**建 src 运行时 helper 只为测试）。用例：
+**`src/self-check.test.ts`** — reuse guard.test.ts's fake (extract into a shared test helper or copy the implementation; **must not** create a src runtime helper only for tests). Cases:
 
-1. 全包装 server → `[]`。
-2. 某 exact 项未包装 → 包含 `"exact <path>"`；fallback 未包装 → `"fallback"`；方法未替换 → `"method register"`。
+1. Fully wrapped server → `[]`.
+2. Some exact entry unwrapped → contains `"exact <path>"`; fallback unwrapped → `"fallback"`; method unreplaced → `"method register"`.
 
-**`src/index.test.ts`** — 假 ctx（`{ get, provide, logger, effect }` 记录调用，effect 存储 disposer）。用例：
+**`src/index.test.ts`** — fake ctx (`{ get, provide, logger, effect }` recording calls, effect stores the disposer). Cases:
 
-1. 形状：`name === "dsh-auth"`；`inject` 含 `"webServer"`。
-2. 无 webServer：`apply` 静默返回（不抛、不 provide）。
-3. 有 webServer + 无 storageDomain：守卫生效（fake server 被包装）、`auth.sessions === undefined`、`log.error` 被调用一次、不抛。
-4. 有 webServer + 有 storageDomain（fake `{ open }`，open 返回带 `table/close` 的假 Domain，resolve 时延）：apply 返回后 microtask 冲洗，`ctx.get("auth").sessions` 为 `SessionStore` 实例。
-5. 自检失败传播：webServer 未包装场景被破坏（如 fake server 的 register 方法在 wrap 后仍不带标记——直接改回原始方法）→ apply 抛 `dsh-auth: guard self-check failed` 且 `log.error` 含条目名。
-6. 注销：逐个调用 effect disposer（逆序），守卫已还原（fake server 表项恢复原 handler 引用）、domain.close 被调用。
-7. Config 默认值：`Config` 校验 `{}` → `{ mode: "token", sessionTtl: 604800, cookieName: "dsh_auth" }`（schemastery 的 `Config(...)` 校验调用，失败即测试失败）。
+1. Shape: `name === "dsh-auth"`; `inject` includes `"webServer"`.
+2. No webServer: `apply` silently returns (does not throw, does not provide).
+3. webServer present + no storageDomain: the guard takes effect (fake server is wrapped), `auth.sessions === undefined`, `log.error` is called once, does not throw.
+4. webServer present + storageDomain present (fake `{ open }`, open returns a fake Domain with `table/close`, delayed resolution): after apply returns and microtasks flush, `ctx.get("auth").sessions` is a `SessionStore` instance.
+5. Self-check failure propagation: the wrapped scenario is broken (e.g., the fake server's register method still lacks the marker after wrap — mutate it straight back to the original method) → apply throws `dsh-auth: guard self-check failed` and `log.error` includes the entry name.
+6. Uninstall: invoke the effect disposers one by one (reverse order), the guard is restored (fake server table entries revert to the original handler references), `domain.close` is called.
+7. Config defaults: `Config` validates `{}` → `{ mode: "token", sessionTtl: 604800, cookieName: "dsh_auth" }` (schemastery's `Config(...)` validation call; the test fails if it fails).
 
-### 5.2 集成测试（真实入口路径——§7 回归纪律的根基）
+### 5.2 Integration Tests (real entry path — the foundation of the §7 regression discipline)
 
-**`src/integration.guard.test.ts`** — 真实 cordis + 真实 WebServer + 真实 HTTP：
+**`src/integration.guard.test.ts`** — real cordis + real WebServer + real HTTP:
 
 ```ts
 import { Context } from "@deepseek-ai/cordis";
@@ -412,23 +410,23 @@ import { apply, inject, name, Config } from "./index.js";
 import type { Gate } from "./gate.js";
 ```
 
-1. setup：`new Context()`；`const wsFiber = await ctx.plugin(WebServer, { host: "127.0.0.1", port: 0 })`；
-   取 `const server = ctx.get("webServer")`（断言存在，类型用 `as unknown as` 缩小）；注册
-   exact `/probe`（200 `"probe"`）、prefix `/pfx`（200 `"pfx"`）、fallback（200 `"spa"`）；
-   再 `const authFiber = await ctx.plugin({ name, inject, apply, Config }, {})`；
-   `const port = server.port`。
-2. NoopGate 放行：`fetch(http://127.0.0.1:${port}/probe)` → 200 `probe`；`/pfx/x` → 200 `pfx`；`/` → 200 `spa`。
-3. 换 deny 门：`const denyGate: Gate = { decide: () => "deny" }; ctx.get("auth")!.gate = denyGate;`
-   - `fetch("/probe", { headers: { accept: "text/html" } })` → 302，`location === "/auth/login?next=%2Fprobe"`；
-   - `fetch("/probe", { headers: { accept: "application/json" } })` → 401，body `unauthorized`；
-   - `fetch("/pfx/x")` → 401（前缀路由也被守）；
-   - `fetch("/")` → 302（fallback 被守）。
-4. WS 拒绝：`node:http` 的 `request({ port, host: "127.0.0.1", path: "/api/events.host", headers: { Connection: "Upgrade", Upgrade: "websocket", "Sec-WebSocket-Key": "x3JJHMbDL1EzLkh9GBhXDw==", "Sec-WebSocket-Version": "13" } })`：
-   期待 `response` 事件、状态 401，**不**触发 `upgrade` 事件（guard 在 ws 协商前拒绝）。
-5. apply 顺序无关：dsh-auth 挂载**之后**再 `server.register({ kind: "exact", path: "/late", handler })` → 立即被守（fetch → 401/302）。
-6. teardown：`await authFiber.dispose(); await wsFiber.dispose();` 后对 port 的请求连接被拒（可断言 fetch rejects）。
+1. setup: `new Context()`; `const wsFiber = await ctx.plugin(WebServer, { host: "127.0.0.1", port: 0 })`;
+   get `const server = ctx.get("webServer")` (assert it exists, narrow the type with `as unknown as`); register
+   exact `/probe` (200 `"probe"`), prefix `/pfx` (200 `"pfx"`), fallback (200 `"spa"`);
+   then `const authFiber = await ctx.plugin({ name, inject, apply, Config }, {})`;
+   `const port = server.port`.
+2. NoopGate allows: `fetch(http://127.0.0.1:${port}/probe)` → 200 `probe`; `/pfx/x` → 200 `pfx`; `/` → 200 `spa`.
+3. Swap in a deny gate: `const denyGate: Gate = { decide: () => "deny" }; ctx.get("auth")!.gate = denyGate;`
+   - `fetch("/probe", { headers: { accept: "text/html" } })` → 302, `location === "/auth/login?next=%2Fprobe"`;
+   - `fetch("/probe", { headers: { accept: "application/json" } })` → 401, body `unauthorized`;
+   - `fetch("/pfx/x")` → 401 (the prefix route is also guarded);
+   - `fetch("/")` → 302 (the fallback is guarded).
+4. WS deny: `node:http`'s `request({ port, host: "127.0.0.1", path: "/api/events.host", headers: { Connection: "Upgrade", Upgrade: "websocket", "Sec-WebSocket-Key": "x3JJHMbDL1EzLkh9GBhXDw==", "Sec-WebSocket-Version": "13" } })`:
+   expect the `response` event, status 401, and the `upgrade` event is **not** emitted (the guard denies before ws negotiation).
+5. Apply-order-independent: mount dsh-auth **then** `server.register({ kind: "exact", path: "/late", handler })` → immediately guarded (fetch → 401/302).
+6. teardown: after `await authFiber.dispose(); await wsFiber.dispose();`, requests to the port are refused (can assert fetch rejects).
 
-**`src/integration.session.test.ts`** — 真实 storage 栈 + 跨重启持久化：
+**`src/integration.session.test.ts`** — real storage stack + persistence across restarts:
 
 ```ts
 import Storage from "@deepseek-ai/dsh-storage";
@@ -436,73 +434,73 @@ import * as storageJson from "@deepseek-ai/dsh-storage-json";
 import * as storageDomain from "@deepseek-ai/dsh-storage-domain";
 ```
 
-1. `mkdtemp` 建临时 root；ctx1：依次 `ctx.plugin(Storage)`、`ctx.plugin(storageJson, { root })`、
-   `ctx.plugin(storageDomain, { backend: "json" })`、再挂本插件（无 webserver 也可——`inject` 只含
-   webServer，故 ctx1 也挂 WebServer `{ host: "127.0.0.1", port: 0 }`），保留全部 Fiber。
-2. `await` 一个小轮询（≤5s，50ms 间隔）直到 `ctx1.get("auth")!.sessions !== undefined`。
-3. `const { token } = await store.create("token", 60_000)`；断言 `getByToken(token)` 返回行；断言
-   `<root>/dsh_auth_sessions.json` 存在且内容含 digest 键（读文件、`JSON.parse`、
-   断言 `doc.tables.sessions[digest]` 存在——文件结构见 §2.2）。
-4. 逆序 dispose ctx1 全部 Fiber。
-5. ctx2：同一 root、同一栈、同样等待 sessions ready；`getByToken(token)` 返回相同 `subject` 与
-   `expiresAt`（**跨"重启"持久化成立**）。
-6. teardown：dispose + `rmSync(root, { recursive: true, force: true })`。
+1. `mkdtemp` creates a temp root; ctx1: in order `ctx.plugin(Storage)`, `ctx.plugin(storageJson, { root })`,
+   `ctx.plugin(storageDomain, { backend: "json" })`, then mount this plugin (a webserver is optional too — `inject` only contains
+   webServer, so ctx1 also mounts WebServer `{ host: "127.0.0.1", port: 0 }`), keep all Fibers.
+2. `await` a small poll (≤5s, 50ms interval) until `ctx1.get("auth")!.sessions !== undefined`.
+3. `const { token } = await store.create("token", 60_000)`; assert `getByToken(token)` returns a row; assert
+   `<root>/dsh_auth_sessions.json` exists and its content contains the digest key (read the file, `JSON.parse`,
+   assert `doc.tables.sessions[digest]` exists — file structure see §2.2).
+4. Dispose all ctx1 Fibers in reverse order.
+5. ctx2: same root, same stack, same wait for sessions ready; `getByToken(token)` returns the same `subject` and
+   `expiresAt` (persistence across "restart" holds).
+6. teardown: dispose + `rmSync(root, { recursive: true, force: true })`.
 
-> 若测试失败且失败原因是某 harness 包行为与本文件不符：**停下报告差异**，不要改测试去迁就。
+> If a test fails and the failure cause is some harness package behavior that does not match this file: **stop and report the discrepancy**, do not change the test to accommodate it.
 
 ---
 
-## 6. 实施顺序（按序执行，每步保持 `npm run verify` 可绿）
+## 6. Implementation Order (execute in order, keep `npm run verify` green at every step)
 
-1. `package.json` 依赖变更 + `npm install --registry=https://registry.npmjs.org/`。
-2. `src/gate.ts` → `src/gate.test.ts`（先绿）。
-3. `src/guard.ts` → `src/guard.test.ts`。
-4. `src/session-store.ts` → `src/session-store.test.ts`。
-5. `src/self-check.ts` → `src/self-check.test.ts`。
-6. `src/index.ts`（重写，替换现有骨架）→ `src/index.test.ts`（重写）。
-7. 集成测试两个文件（最后写：依赖前五步稳定）。
-8. `docs/development.md` 的 `## Structure` 树更新为：
+1. `package.json` dependency changes + `npm install --registry=https://registry.npmjs.org/`.
+2. `src/gate.ts` → `src/gate.test.ts` (green first).
+3. `src/guard.ts` → `src/guard.test.ts`.
+4. `src/session-store.ts` → `src/session-store.test.ts`.
+5. `src/self-check.ts` → `src/self-check.test.ts`.
+6. `src/index.ts` (rewrite, replacing the existing skeleton) → `src/index.test.ts` (rewrite).
+7. The two integration test files (write last: they depend on the stability of the previous five steps).
+8. Update the `## Structure` tree in `docs/development.md` to:
    ```
    src/
-   ├── index.ts          # plugin entry: name / inject / Config / apply + auth 服务接线
-   ├── guard.ts          # webServer 路由/升级/fallback 包装与拒绝管线
-   ├── gate.ts           # Gate 词表 + noopGate（M2 换真门）
-   ├── session-store.ts  # storage-domain 会话持久化
-   ├── self-check.ts     # 包装覆盖自检（fail loud）
-   ├── *.test.ts         # 单元测试（显式 vitest import）
-   └── integration.*.test.ts  # 真实 cordis/webserver/storage 栈集成测试
+   ├── index.ts          # plugin entry: name / inject / Config / apply + auth service wiring
+   ├── guard.ts          # webServer route/upgrade/fallback wrapping and deny pipeline
+   ├── gate.ts           # Gate vocabulary + noopGate (M2 swaps in the real gate)
+   ├── session-store.ts  # storage-domain session persistence
+   ├── self-check.ts     # wrapping-coverage self-check (fail loud)
+   ├── *.test.ts         # unit tests (explicit vitest imports)
+   └── integration.*.test.ts  # real cordis/webserver/storage stack integration tests
    ```
 
 ---
 
-## 7. Definition of Done（全部满足才算完成）
+## 7. Definition of Done (the task is complete only when all are satisfied)
 
-1. `npm run verify` 全绿（format:check + lint + type-check + test:coverage ≥80% + lock:check）。
-2. `npm run build` 成功且 `lib/` 已重新生成；`git status` 中 `src/` 与 `lib/` 同批改动（AGENTS.md 提交纪律，未获指令**不 commit 不 push**）。
-3. `npm run test -- src/integration.guard.test.ts src/integration.session.test.ts` 单独跑也绿。
-4. 报告中列出：改动文件清单、每个冻结决策（D1–D16）的落点文件、覆盖率数字、任何与本文档不一致之处（应为零；有则视为未完成）。
-
----
-
-## 8. 禁区清单（违反 = 返工）
-
-- **不探索 harness 内部**：只信本文档 §2 的事实。需要新事实 → 停下报告。
-- **不发明 API**：`webServer` 没有中间件/事件钩子；storage 只有 §2.2 列出的接口。
-- **不吞错误**：handler 错误向上抛；`open` 失败走 `log.error` 分支后守卫仍挂载（D3）。
-- **不留副作用**：所有注册（wrap、domain、provide 由 fiber 自动注销）必须有对应 effect/disposer。
-- **不写 `console.*`**（src 内 lint 报 error）；日志统一 `ctx.logger("dsh-auth")`。
-- **不落敏感值进日志/测试快照**：token 只在内存与响应中出现；测试断言用已知向量，不 print 真实随机 token。
-- **不改门禁**：不得降 coverage 阈值、不得加 eslint-disable（除文件内既有允许项）、不得改 tsconfig/eslint/vitest 配置。
-- **不改依赖之外的 package.json 字段**（version 由 release-please 管，scripts/files/exports 不动）。
-- **不动其他里程碑**：M2+（token 校验、登录页、users.yaml、TOTP、CLI、`cordis.patch.yml`/profile 行文档）不在 M1。写代码时如需要引用，只做 TODO 注释并带稳定 tag（如 `TODO(auth-token-gate):`）。
-- **分支纪律**：所有改动留在 `development`，不碰 `main`，未获指令不 commit/push。
+1. `npm run verify` fully green (format:check + lint + type-check + test:coverage ≥80% + lock:check).
+2. `npm run build` succeeds and `lib/` is regenerated; in `git status`, `src/` and `lib/` are in the same batch of changes (AGENTS.md commit discipline; **do not commit or push** without an instruction).
+3. `npm run test -- src/integration.guard.test.ts src/integration.session.test.ts` run alone is also green.
+4. The report lists: the changed-file inventory, the landing file of each frozen decision (D1–D16), the coverage numbers, and any inconsistency with this document (there should be none; if there is, it counts as incomplete).
 
 ---
 
-## 9. 明确不做（M1 范围之外，勿实现）
+## 8. Forbidden-Zone List (violating = redo)
 
-- 登录页与 `/auth/*` 端点、Bearer/token 校验、credentials 引用（M2）。
-- users.yaml / argon2id / 限速 / `dsh-auth user` CLI（M3）。
-- TOTP 两段式登录（M4）。
-- 部署侧交付物：`cordis.patch.yml` 生产 patch、profile 行文档、部署验收清单（M1 代码交付后单独做）。
-- client 半边（登出按钮等 GUI 组件）。
+- **Do not explore the harness internals**: trust only the facts in §2 of this document. Need a new fact → stop and report.
+- **Do not invent APIs**: `webServer` has no middleware/event hooks; storage has only the interfaces listed in §2.2.
+- **Do not swallow errors**: handler errors are thrown upward; on `open` failure, go through the `log.error` branch then the guard stays mounted (D3).
+- **Do not leave side effects**: every registration (wrap, domain, provide, which are auto-unregistered by the fiber) must have a corresponding effect/disposer.
+- **Do not write `console.*`** (lint reports error in src); logging uniformly via `ctx.logger("dsh-auth")`.
+- **Do not put sensitive values into logs/test snapshots**: tokens appear only in memory and in responses; test assertions use known vectors, do not print real random tokens.
+- **Do not change the gates**: must not lower the coverage threshold, must not add eslint-disable (except existing per-file allowances), must not change tsconfig/eslint/vitest config.
+- **Do not change package.json fields beyond dependencies** (version is owned by release-please; don't touch scripts/files/exports).
+- **Do not touch other milestones**: M2+ (token validation, login page, users.yaml, TOTP, CLI, `cordis.patch.yml`/profile-line documentation) is not in M1. When writing code that needs a reference, only write a TODO comment with a stable tag (e.g., `TODO(auth-token-gate):`).
+- **Branch discipline**: keep all changes on `development`, do not touch `main`, do not commit/push without an instruction.
+
+---
+
+## 9. Explicitly Not Done (outside M1 scope, do not implement)
+
+- Login page and `/auth/*` endpoints, Bearer/token validation, credentials references (M2).
+- users.yaml / argon2id / rate limiting / `dsh-auth user` CLI (M3).
+- TOTP two-stage login (M4).
+- Deployment-side deliverables: `cordis.patch.yml` production patch, profile-line documentation, deployment acceptance checklist (done separately after M1 code delivery).
+- The client half (logout button and other GUI components).

--- a/docs/impl-m1_zh.md
+++ b/docs/impl-m1_zh.md
@@ -1,0 +1,508 @@
+# dsh-auth M1 实施规格（executable spec）
+
+> 读者：执行实现的编码代理（预期 deepseek v4 flash）。本文档是**决策完备的规格**：
+> 所有判断点已预先关闭，执行者只做翻译，不做设计。
+> 设计依据见 `docs/dsh-auth-plan_zh.md`；工程门禁见 `docs/development.md`；本文件是两者在
+> M1 范围内的唯一权威细则——冲突时以本文件为准。
+>
+> 所有挂载点事实均已在 `@deepseek-ai/*@0.1.0-rc.6` / `@deepseek-ai/cordis@4.0.1`
+> 真实源码与类型声明上核实。**禁止自行探索 harness 内部实现**：需要任何未在本文件
+> 出现的事实（字段、签名、行为）时，停下并报告，不得猜测。
+
+---
+
+## 1. 冻结决策表
+
+| #   | 决策               | 冻结值                                                                                                                                                             |
+| --- | ------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| D1  | M1 门行为          | 守卫管线（包装 + 302/401/拒握手）全部实现；`gate` 为 `noopGate`（全放行）。M2 只换 gate，不动守卫                                                                  |
+| D2  | 插件依赖           | 硬依赖 `inject: ["webServer"]`；`storageDomain` 用 `ctx.get()` 软读                                                                                                |
+| D3  | storageDomain 缺失 | `ctx.logger("dsh-auth").error(...)` 后**继续挂载守卫**（M1 门是惰性的；M2 起改为运行时 deny-all fail-closed）                                                      |
+| D4  | auth 服务          | `ctx.provide("auth", { sessions, gate })`；`gate` 是可写字段（M2 换流、测试注入假门）；类型增强 `declare module "@deepseek-ai/cordis"`                             |
+| D5  | 守卫标记           | `Symbol.for("dsh-auth.guarded")` 挂在被包装 handler/方法上；重复包装幂等（已标记则原样返回）                                                                       |
+| D6  | 生命周期可逆       | `ctx.effect` 注册还原器；还原器反向执行：先撤守卫，再关 domain。还原 = 恢复快照 + 原方法                                                                           |
+| D7  | 拒绝响应           | 浏览器导航（GET 且 `Accept` 含 `text/html`）→ `302 /auth/login?next=<encoded pathname>`；其余 HTTP → `401` body `unauthorized`；两者都带 `cache-control: no-store` |
+| D8  | WS 拒绝            | 不进入 ws 协商：`socket.write("HTTP/1.1 401 Unauthorized\r\nConnection: close\r\n\r\n")` 后 `socket.destroy()`；守卫不为 socket 附加任何监听器                     |
+| D9  | 自检失败           | 逐条 `logger.error` 后 `throw new Error("dsh-auth: guard self-check failed: ...")`（fiber 启动失败 = fail loud）                                                   |
+| D10 | 会话 token         | `randomBytes(32).toString("base64url")`（43 字符，无填充）；落盘键 = `sha256` hex 小写（64 字符）；**日志永不输出完整 token**                                      |
+| D11 | 会话 TTL           | 默认 `604800` 秒（7 天），自创建起固定过期、不滑动                                                                                                                 |
+| D12 | 登出语义           | 吊销 = 删除行（`delete`）；`pruneExpired` 在每次 `create` 前全表扫描清理过期行                                                                                     |
+| D13 | Cookie             | `buildSetCookie(name, token, maxAge)` 输出精确格式 `<name>=<token>; Max-Age=<secs>; Path=/; HttpOnly; Secure; SameSite=Lax`（M2 使用，M1 冻结并测试）              |
+| D14 | Config             | schemastery（与 harness 一致）；record schema 用 zod（storage-domain 的分工约定）                                                                                  |
+| D15 | 模块系统           | NodeNext；相对导入一律 `.js` 后缀；禁 `console.*`；日志走 `ctx.logger("dsh-auth")`                                                                                 |
+| D16 | 幂等重挂           | 同一 server 第二次 `wrapServer` 返回同一 unwrap（`WeakMap` 记录），不产生双守卫                                                                                    |
+
+---
+
+## 2. 权威契约（挂载点事实）
+
+### 2.1 `webServer` 服务（`@deepseek-ai/dsh-host-webserver@0.1.0-rc.6`）
+
+运行时事实（`private` 仅是 TS 层面，运行时全部可达）：
+
+- 表：`server.exact: Map<string, WebRoute>`、`server.prefixes: Map<string, WebRoute>`、
+  `server.upgrades: Map<string, WebUpgradeRoute>`；`server.fallback: handler | undefined`。
+- `WebRoute = { kind: "exact" | "prefix"; path: string; handler: (req, res) => void | Promise<void> }`；
+  `WebUpgradeRoute = { path: string; handler: (req, socket: Duplex, head: Buffer) => void | Promise<void> }`。
+- 注册方法：`register(route)`（重复 `(kind, path)` 抛错）、`registerUpgrade(route)`（重复 path 抛错）、
+  `registerFallback(handler)`（第二个抛错）。**三者都返回 disposer**，disposer 按 path 删表项——
+  原地替换表项内容不破坏已发出 disposer 的语义。
+- 分发（请求时查表）：`match(pathname)` = exact 表精确命中 → 否则最长前缀（`pathname === prefix` 或
+  `pathname.startsWith(prefix + "/")`）→ 否则 fallback → 否则 404。
+- 升级分发：`upgrade` 事件里 `this.upgrades.get(new URL(req.url ?? "/", "http://x").pathname)`，
+  未命中销毁 socket。
+- 错误处理：async handler 抛错由 webserver 统一捕获：`ctx.logger.warn` + 未发头则 400 / 已发头则 destroy。
+  守卫**不得吞掉 handler 错误**（直接向上抛，交给这条路径）。
+- 服务形态：`WebServer extends Service`，`super(ctx, "webServer")` 注册服务；`static Config` 为
+  schemastery（`host: "127.0.0.1" | "0.0.0.0"`，`port: z.natural().max(65535)`，port 0 = 系统分配）。
+  挂载后监听立即生效（`[Service.init]`），`instance.port` 是最终监听端口。
+
+### 2.2 storage domain（`@deepseek-ai/dsh-storage-domain@0.1.0-rc.6`）
+
+- 模块导出：`defineDomain(spec)`、`domainTable(zodSchema)`；`ctx.storageDomain: DomainFacility`。
+- `DomainFacility.open(spec): Promise<Domain<S>>` —— **调用者拥有返回的 handle**，必须自己在
+  effect disposer 里 `await domain.close()`（幂等）。
+- `Domain<S>`：`domain.table(name): KvTable<K, V>`（handle 稳定，可重复取）；`domain.close(): Promise<void>`。
+- `KvTable`：`get(key): V | undefined`（同步内存读）、`put(key, value): Promise<void>`、
+  `delete(key): Promise<boolean>`、`entries(): IterableIterator<[K, V]>`（快照迭代）、`size: number`。
+  写先落介质再改内存；返回的记录是存储对象本身，**不得原地修改**。
+- `DomainSpec = { name: string; version: number; global?: ...; tables: Record<string, DomainTableSpec> }`。
+  spec 的 record schema 用 **zod**（`z.infer` 派生类型，不手写重复类型）。
+- **名称约束（实测核实）**：`DomainSpec.name` 与表名都必须匹配
+  `UNIT_NAME_RE = /^[a-z][a-z0-9_]*$/`（`@deepseek-ai/dsh-storage` 导出）——**禁止连字符**，
+  否则 `defineDomain` 在模块加载时抛错。故本插件 domain 名为 `dsh_auth_sessions`（下划线）。
+- 后端：`dsh-storage-json` 以 `backend: "json"` 注册，root 下每 unit 一个 `<unit>.json` 文件；
+  文件格式（实测核实）：`{ unit: { name, version }, global, tables: { <table>: { <key>: record } } }`，
+  pretty-printed + 末尾换行。`dsh-storage-domain` 的 Config `{ backend: "json" }`（本机 web profile 已这样配置）。
+- 真实 web 组合中 `storage-domain` 行在 bundle 层（`dsh-web-app`），profile 层之后才挂我们的行，
+  因此 apply 时 `ctx.get("storageDomain")` 正常可见；集成测试中先挂 storage 栈再挂本插件。
+
+### 2.3 cordis Context（`@deepseek-ai/cordis@4.0.1`）
+
+- 对象插件形状：`{ name, inject, apply, Config }`；`inject` 声明的服务可用后 apply 才执行。
+- `ctx.get(name)` 软读；`ctx.provide(name, value)` 提供服务（随 fiber 自动注销）。
+- `ctx.effect(callback, label)`：callback 返回 disposer（同步或异步皆可），fiber 卸载时
+  **按注册逆序**执行 disposer。挂载：`ctx.plugin(plugin, ...config)` 返回 `Fiber & PromiseLike<Fiber>`，
+  `Fiber.dispose(): Promise<void>` 卸载。
+- `ctx.logger` 本身是 logger 实例；`ctx.logger("dsh-auth")` 返回命名 logger（`error/warn/info`）。
+- `new Context()` 自带内建服务（logger/registry/reflect）。
+
+---
+
+## 3. 依赖变更（`package.json`）
+
+```jsonc
+{
+  "dependencies": {
+    "@deepseek-ai/dsh-storage-domain": "^0.1.0-rc.6", // 新增：src 运行时 import（defineDomain/domainTable）
+    "@deepseek-ai/schemastery": "^3.18.1", // 已有
+    "zod": "^4.4.3", // 已有
+  },
+  "peerDependencies": {
+    "@deepseek-ai/cordis": "^4.0.1", // 从 dependencies 移入（宿主提供实例）
+  },
+  "devDependencies": {
+    // 新增（仅测试/类型）：
+    "@deepseek-ai/cordis": "^4.0.1",
+    "@deepseek-ai/dsh-host-webserver": "^0.1.0-rc.6",
+    "@deepseek-ai/dsh-storage": "^0.1.0-rc.6",
+    "@deepseek-ai/dsh-storage-json": "^0.1.0-rc.6",
+    // 其余保持不动
+  },
+}
+```
+
+- 安装必须 `npm install --registry=https://registry.npmjs.org/`（AGENTS.md 锁仓规则；全部包已在
+  公共 npm 核实存在，版本精确）。
+- src 中**不得** import `dsh-host-webserver`/`dsh-storage`/`dsh-storage-json`（它们只出现在测试里）；
+  src 对 webserver 用自定义结构类型（§4.2）。
+
+---
+
+## 4. 文件蓝图
+
+每个文件：职责、导出签名、行为约定、长度预算（文件 ≤250 行、函数 ≤80 行、复杂度 ≤15，均为
+ESLint error，违反即红）。
+
+### 4.1 `src/gate.ts` —— 门决策词表与惰性门
+
+```ts
+import type { IncomingMessage } from "node:http";
+
+/** Guard 判定时报告的被包装入口类别。 */
+export type GuardKind = "exact" | "prefix" | "upgrade" | "fallback";
+
+/** allow = 放行原 handler；deny = 由守卫执行 302/401/拒握手（§D7/D8）。 */
+export type GateDecision = "allow" | "deny";
+
+export interface Gate {
+  decide(
+    req: IncomingMessage,
+    kind: GuardKind,
+    pathname: string,
+  ): GateDecision | Promise<GateDecision>;
+}
+
+/** M1 惰性门：恒放行。M2 用 token/密码门整体替换。 */
+export const noopGate: Gate = { decide: () => "allow" };
+```
+
+行为约定：`GuardKind` 定义在此处（`guard.ts` 依赖它，方向单向，无循环 import）。
+
+### 4.2 `src/guard.ts` —— 包装机制与拒绝管线（核心风险文件）
+
+```ts
+import type { IncomingMessage, ServerResponse } from "node:http";
+import type { Duplex } from "node:stream";
+import type { Gate, GuardKind } from "./gate.js";
+
+export const GUARDED: unique symbol = Symbol.for("dsh-auth.guarded");
+export const LOGIN_PATH = "/auth/login";
+
+export type HttpHandler = (req: IncomingMessage, res: ServerResponse) => void | Promise<void>;
+export type UpgradeHandler = (
+  req: IncomingMessage,
+  socket: Duplex,
+  head: Buffer,
+) => void | Promise<void>;
+
+export interface WrappableRoute {
+  kind: "exact" | "prefix";
+  path: string;
+  handler: HttpHandler;
+}
+export interface WrappableUpgradeRoute {
+  path: string;
+  handler: UpgradeHandler;
+}
+
+/** webServer 运行时形状的结构镜像（§2.1）；真实实例运行时满足它。 */
+export interface WrappableServer {
+  exact: Map<string, WrappableRoute>;
+  prefixes: Map<string, WrappableRoute>;
+  upgrades: Map<string, WrappableUpgradeRoute>;
+  fallback: HttpHandler | undefined;
+  register(route: WrappableRoute): () => void;
+  registerUpgrade(route: WrappableUpgradeRoute): () => void;
+  registerFallback(handler: HttpHandler): () => void;
+}
+
+export type GuardLog = { error(message: unknown): void };
+
+// 签名说明：`Function` 被 lint（no-unsafe-function-type）禁用，用任意函数形
+// 式 `(...args: never[]) => unknown` 表达"接受任意 callable"。
+export function isGuarded(target: (...args: never[]) => unknown): boolean;
+export function guardHttp(gate: () => Gate, kind: GuardKind, handler: HttpHandler): HttpHandler;
+export function guardUpgrade(gate: () => Gate, handler: UpgradeHandler): UpgradeHandler;
+export function denyHttp(req: IncomingMessage, res: ServerResponse): void;
+export function denyUpgrade(socket: Duplex): void;
+export function wrapServer(server: WrappableServer, gate: () => Gate, log: GuardLog): () => void;
+```
+
+实现约定（逐条执行，不得偏离）：
+
+- `guardHttp`：若 `handler[GUARDED] === true` 原样返回（D5 幂等）。否则返回标记过的
+  `async (req, res) => { const pathname = new URL(req.url ?? "/", "http://x").pathname; const d = await gate().decide(req, kind, pathname); if (d === "allow") { await handler(req, res); return; } denyHttp(req, res); }`。
+  错误不捕获（§2.1 webserver 统一处理）。
+- `guardUpgrade`：同构；deny 分支调 `denyUpgrade(socket)`，不调原 handler，不附加 socket 监听器。
+- `denyHttp`：`res.setHeader("cache-control", "no-store")`；`req.method === "GET"` 且
+  `String(req.headers.accept ?? "").includes("text/html")` → `res.writeHead(302, { location: `${LOGIN_PATH}?next=${encodeURIComponent(pathname)}` }); res.end();`；
+  否则 `res.writeHead(401, { "content-type": "text/plain" }); res.end("unauthorized");`。
+  header 名用小写（node 规范化为小写）。
+- `denyUpgrade`：先 `socket.write("HTTP/1.1 401 Unauthorized\r\nConnection: close\r\n\r\n")` 再
+  `socket.destroy()`。
+- `wrapServer`：
+  1. 模块级 `const unwrappers = new WeakMap<WrappableServer, () => void>()`；已存在则返回既有 unwrap（D16）。
+  2. 捕获 `orig = { register: server.register.bind(server), registerUpgrade: ..., registerFallback: ... }`
+     与快照 `{ exact: new Map(server.exact), prefixes: ..., upgrades: ..., fallback: server.fallback }`。
+  3. 原地替换存量：`for (const [p, r] of server.exact) server.exact.set(p, { ...r, handler: guardHttp(gate, "exact", r.handler) })`；
+     prefixes 同理（kind 用 `r.kind`）；upgrades 用 `guardUpgrade`；`fallback` 存在则
+     `server.fallback = guardHttp(gate, "fallback", server.fallback)`。
+  4. 替换实例方法（增量保险，apply 顺序无关）：
+     `server.register = (route) => orig.register({ ...route, handler: guardHttp(gate, route.kind, route.handler) })`；
+     `registerUpgrade` 用 `guardUpgrade`；`registerFallback = (h) => orig.registerFallback(guardHttp(gate, "fallback", h))`。
+     三个替换后的函数都置 `[GUARDED] = true`（自检用，§4.4）。
+  5. 返回 unwrap（并存入 WeakMap）：清空四个表并按快照回填（`server.exact.clear()` 后逐个 set 快照项）、
+     `server.fallback = snapshot.fallback`、三个方法还原为 `orig.*`。post-wrap 期间新增的注册随还原丢弃
+     （disposer 仍按 path 操作当前表，语义安全——还原即整体回滚）。
+- `gate: () => Gate` 是访问器而非值：闭包每次请求读最新门（M2 换流、测试注入假门都靠这个）。
+
+### 4.3 `src/session-store.ts` —— 持久化会话（storage domain）
+
+```ts
+import { defineDomain, domainTable, type KvTable } from "@deepseek-ai/dsh-storage-domain";
+import { createHash, randomBytes } from "node:crypto";
+import { z } from "zod";
+
+export const COOKIE_FLAGS = "Path=/; HttpOnly; Secure; SameSite=Lax";
+
+export function buildSetCookie(cookieName: string, token: string, maxAgeSeconds: number): string;
+// 精确输出：`${cookieName}=${token}; Max-Age=${maxAgeSeconds}; ${COOKIE_FLAGS}`
+
+export function digestToken(token: string): string; // createHash("sha256").update(token).digest("hex")
+
+export interface Session {
+  subject: string; // 审计用：产生该会话的凭证身份（M1 恒 "token"，M2 为用户名）
+  createdAt: number; // epoch ms
+  expiresAt: number; // epoch ms
+  revoked: boolean;
+}
+
+export interface IssuedSession {
+  token: string;
+  session: Session;
+}
+
+const sessionRowSchema = z.object({
+  subject: z.string(),
+  createdAt: z.number().int().nonnegative(),
+  expiresAt: z.number().int().nonnegative(),
+  revoked: z.boolean(),
+});
+// 键 = digest（64 位 hex 小写），不进 row；row 只存以上四字段。
+
+export const sessionDomainSpec = defineDomain({
+  name: "dsh_auth_sessions", // 必须匹配 UNIT_NAME_RE（无连字符，见 §2.2）
+  version: 0,
+  tables: { sessions: domainTable(sessionRowSchema) },
+});
+
+export class SessionStore {
+  constructor(table: KvTable<string, Session>);
+  create(subject: string, ttlMs: number): Promise<IssuedSession>;
+  getByToken(token: string): Session | undefined; // 同步：哈希 → 内存读 → 校验
+  revokeByToken(token: string): Promise<boolean>; // delete 的返回值直传
+  pruneExpired(now?: number): Promise<number>; // 删全部过期行，返回删除数
+}
+```
+
+行为约定：
+
+- `create`：先 `await this.pruneExpired()`；`token = randomBytes(32).toString("base64url")`；
+  `now = Date.now()`；`put(digest, { subject, createdAt: now, expiresAt: now + ttlMs, revoked: false })`；
+  返回 `{ token, session: 同 row }`。
+- `getByToken`：`const row = table.get(digestToken(token))`；`row === undefined || row.revoked || row.expiresAt <= Date.now()` → `undefined`；否则返回 row（**不修改 row**）。
+- `pruneExpired(now = Date.now())`：`entries()` 遍历，`expiresAt <= now` 的 `await table.delete(key)`，返回计数。
+- 本模块**不**负责 domain 的 open/close（那是 `index.ts` 的接线职责）；类对 `KvTable` 编程，
+  单测用内存假表，集成测试用真栈。
+
+### 4.4 `src/self-check.ts` —— 启动自检
+
+```ts
+import type { WrappableServer } from "./guard.js";
+
+/** 返回未被守卫标记覆盖的入口清单，形如 "exact /api"、"fallback"、"method register"。空 = 通过。 */
+export function assertGuarded(server: WrappableServer): string[];
+```
+
+行为约定：逐一检查四表全部 handler、`fallback`、以及三个注册方法（替换后的方法带 `[GUARDED]` 标记），
+未标记的条目入列。此文件**只报告，不修复、不抛错**（抛错由 `index.ts` 决定）。
+
+### 4.5 `src/index.ts` —— 插件入口与接线
+
+```ts
+import type { Context } from "@deepseek-ai/cordis";
+import type { DomainFacility } from "@deepseek-ai/dsh-storage-domain";
+import z from "@deepseek-ai/schemastery";
+import { noopGate, type Gate } from "./gate.js";
+import { assertGuarded } from "./self-check.js";
+import { wrapServer, type WrappableServer } from "./guard.js";
+import { sessionDomainSpec, SessionStore } from "./session-store.js";
+
+export const name = "dsh-auth";
+export const inject = ["webServer"] as const;
+
+export interface AuthConfig {
+  mode: "token" | "password"; // M1 只进 schema；token 门 M2 生效
+  sessionTtl: number;          // 秒；默认 604800（7 天）
+  cookieName: string;          // 默认 "dsh_auth"
+}
+
+export const Config: z<AuthConfig> = z.object({
+  mode: z.union([z.const("token"), z.const("password")]).default("token"),
+  sessionTtl: z.natural().default(604800),
+  cookieName: z.string().default("dsh_auth"),
+});
+
+export interface AuthService {
+  sessions: SessionStore | undefined; // storageDomain 缺失时为 undefined（D3）
+  gate: Gate;                         // 可写：M2 换流、测试注入假门
+}
+
+declare module "@deepseek-ai/cordis" {
+  interface Context { auth?: AuthService; }
+}
+
+export function apply(ctx: Context, config: AuthConfig): void { ... }
+```
+
+`apply` 接线骨架（照此实现，勿改顺序）：
+
+1. `const server = ctx.get("webServer") as unknown as WrappableServer | undefined;` 为 `undefined` 则 `return`（inject 已保证存在，防御性短路）。
+2. `const log = ctx.logger("dsh-auth");`
+3. `const auth: AuthService = { sessions: undefined, gate: noopGate }; ctx.provide("auth", auth);`
+4. 会话层（软接 storageDomain）：
+   `const storageDomain = ctx.get("storageDomain") as unknown as DomainFacility | undefined;`
+   - 缺失：`log.error("storage-domain is unavailable: session persistence is disabled (guards stay mounted)");`
+   - 存在：`ctx.effect(() => { let closed = false; const opening = storageDomain.open(sessionDomainSpec); const ready = opening.then((domain) => { if (closed) { void domain.close(); return; } auth.sessions = new SessionStore(domain.table("sessions")); log.info("session domain opened: dsh_auth_sessions"); }, (error: unknown) => { log.error(`session domain open failed: ${error instanceof Error ? error.message : String(error)}`); }); return async () => { closed = true; await ready.catch(() => undefined); const domain = await opening.catch(() => undefined); await domain?.close(); }; }, "dsh-auth: session domain");`
+     （注意：`ready` 挂 `.then` 后解析为 `void`，disposer 必须从**原始** `opening` promise 取 domain 来 close，否则 domain 泄漏。）
+5. 守卫：`const unwrap = wrapServer(server, () => auth.gate, log); ctx.effect(() => unwrap, "dsh-auth: guard unwrap");`
+   （effect 逆序注销保证：先撤守卫，后关 domain。）
+6. 自检：`const failures = assertGuarded(server); if (failures.length > 0) { for (const f of failures) log.error("unwrapped entry: " + f); throw new Error("dsh-auth: guard self-check failed: " + failures.join(", ")); }`
+
+其他约定：不记录/输出 config 中的任何敏感值（M1 的 config 无敏感值，但日志只打事件名与路径，不打 token）。`AuthService`/`AuthConfig` 导出的类型只引用自身定义与 `SessionStore`/`Gate`（自包类型），不泄漏 storage-domain/webserver 包类型到公开 d.ts。
+
+---
+
+## 5. 测试矩阵
+
+全部用 Vitest，显式 import（`import { describe, expect, it, beforeAll, afterAll } from "vitest"`），
+环境 node。既有 `src/index.test.ts` **整体重写**为下述用例。覆盖率红线 80%（branches/functions/
+lines/statements）照常适用。
+
+### 5.1 单元测试
+
+**`src/gate.test.ts`** — `noopGate.decide` 对任意参数返回 `"allow"`（1 个用例）。
+
+**`src/guard.test.ts`** — 本文件内定义 `makeFakeServer(): WrappableServer`（Map 表 + 记录调用次数的
+register/registerUpgrade/registerFallback，返回删除用 disposer），假 `req/res/socket` 为最小对象
+（`res: { headersSent, setHeader, writeHead, end }`、`socket: { write, destroy }` 记录调用）。用例：
+
+1. 存量包装：四表 + fallback 的 handler 均被替换（引用不等）且 `isGuarded` 为真；allow 时原 handler 以原参数被调用。
+2. 增量包装：wrap 之后 `server.register(route)` 注册的 handler 带守卫；deny 时原 handler 不被调用且收到 401。
+3. 幂等：`wrapServer` 调两次，handler 只包一层（第二次返回同一 unwrap）；unwrap 后四表/方法/fallback 与包装前逐引用相等。
+4. 拒绝-HTTP：`GET` + `Accept: text/html` → `writeHead(302)` 且 `location === "/auth/login?next=%2Fsome%2Fpath"`、`cache-control: no-store`；非导航（`Accept: application/json` 或 `POST`）→ `writeHead(401)`、body `unauthorized`。
+5. 拒绝-升级：deny → `socket.write` 收到以 `HTTP/1.1 401 Unauthorized` 开头的内容、`socket.destroy` 被调、原 handler 未被调；allow → 原 handler 收到 `(req, socket, head)`。
+6. 错误传播：原 handler reject 时守卫不捕获（`await expect(...).rejects.toThrow`）。
+7. gate 访问器：先 deny 门 → 401；把门换成 allow → 200 路径（证明运行时换门生效）。
+
+**`src/session-store.test.ts`** — 文件内 `class MemTable implements KvTable<string, Session>`（Map 实现）。
+用例：
+
+1. `digestToken` 已知向量：`digestToken("abc") === "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad"`。
+2. `create`：token 匹配 `/^[A-Za-z0-9_-]{43}$/`；行已 `put`，键 = digest，`createdAt/expiresAt` 差值 = ttlMs，`revoked === false`，`subject` 透传。
+3. `getByToken`：有效 token → 返回行；未知 token → `undefined`；已过期（`expiresAt <= Date.now()`）→ `undefined`；`revoked: true` → `undefined`。
+4. `revokeByToken`：存在 → `true` 且行删除；不存在 → `false`。
+5. `pruneExpired`：混合有效/过期行，只删过期、返回精确计数、有效行原样保留。
+6. `buildSetCookie` 精确串：`buildSetCookie("dsh_auth", "tok", 604800) === "dsh_auth=tok; Max-Age=604800; Path=/; HttpOnly; Secure; SameSite=Lax"`。
+
+**`src/self-check.test.ts`** — 复用 guard.test.ts 的 fake（提取到测试内共享 helper 或复制实现；**不得**建 src 运行时 helper 只为测试）。用例：
+
+1. 全包装 server → `[]`。
+2. 某 exact 项未包装 → 包含 `"exact <path>"`；fallback 未包装 → `"fallback"`；方法未替换 → `"method register"`。
+
+**`src/index.test.ts`** — 假 ctx（`{ get, provide, logger, effect }` 记录调用，effect 存储 disposer）。用例：
+
+1. 形状：`name === "dsh-auth"`；`inject` 含 `"webServer"`。
+2. 无 webServer：`apply` 静默返回（不抛、不 provide）。
+3. 有 webServer + 无 storageDomain：守卫生效（fake server 被包装）、`auth.sessions === undefined`、`log.error` 被调用一次、不抛。
+4. 有 webServer + 有 storageDomain（fake `{ open }`，open 返回带 `table/close` 的假 Domain，resolve 时延）：apply 返回后 microtask 冲洗，`ctx.get("auth").sessions` 为 `SessionStore` 实例。
+5. 自检失败传播：webServer 未包装场景被破坏（如 fake server 的 register 方法在 wrap 后仍不带标记——直接改回原始方法）→ apply 抛 `dsh-auth: guard self-check failed` 且 `log.error` 含条目名。
+6. 注销：逐个调用 effect disposer（逆序），守卫已还原（fake server 表项恢复原 handler 引用）、domain.close 被调用。
+7. Config 默认值：`Config` 校验 `{}` → `{ mode: "token", sessionTtl: 604800, cookieName: "dsh_auth" }`（schemastery 的 `Config(...)` 校验调用，失败即测试失败）。
+
+### 5.2 集成测试（真实入口路径——§7 回归纪律的根基）
+
+**`src/integration.guard.test.ts`** — 真实 cordis + 真实 WebServer + 真实 HTTP：
+
+```ts
+import { Context } from "@deepseek-ai/cordis";
+import WebServer from "@deepseek-ai/dsh-host-webserver";
+import { apply, inject, name, Config } from "./index.js";
+import type { Gate } from "./gate.js";
+```
+
+1. setup：`new Context()`；`const wsFiber = await ctx.plugin(WebServer, { host: "127.0.0.1", port: 0 })`；
+   取 `const server = ctx.get("webServer")`（断言存在，类型用 `as unknown as` 缩小）；注册
+   exact `/probe`（200 `"probe"`）、prefix `/pfx`（200 `"pfx"`）、fallback（200 `"spa"`）；
+   再 `const authFiber = await ctx.plugin({ name, inject, apply, Config }, {})`；
+   `const port = server.port`。
+2. NoopGate 放行：`fetch(http://127.0.0.1:${port}/probe)` → 200 `probe`；`/pfx/x` → 200 `pfx`；`/` → 200 `spa`。
+3. 换 deny 门：`const denyGate: Gate = { decide: () => "deny" }; ctx.get("auth")!.gate = denyGate;`
+   - `fetch("/probe", { headers: { accept: "text/html" } })` → 302，`location === "/auth/login?next=%2Fprobe"`；
+   - `fetch("/probe", { headers: { accept: "application/json" } })` → 401，body `unauthorized`；
+   - `fetch("/pfx/x")` → 401（前缀路由也被守）；
+   - `fetch("/")` → 302（fallback 被守）。
+4. WS 拒绝：`node:http` 的 `request({ port, host: "127.0.0.1", path: "/api/events.host", headers: { Connection: "Upgrade", Upgrade: "websocket", "Sec-WebSocket-Key": "x3JJHMbDL1EzLkh9GBhXDw==", "Sec-WebSocket-Version": "13" } })`：
+   期待 `response` 事件、状态 401，**不**触发 `upgrade` 事件（guard 在 ws 协商前拒绝）。
+5. apply 顺序无关：dsh-auth 挂载**之后**再 `server.register({ kind: "exact", path: "/late", handler })` → 立即被守（fetch → 401/302）。
+6. teardown：`await authFiber.dispose(); await wsFiber.dispose();` 后对 port 的请求连接被拒（可断言 fetch rejects）。
+
+**`src/integration.session.test.ts`** — 真实 storage 栈 + 跨重启持久化：
+
+```ts
+import Storage from "@deepseek-ai/dsh-storage";
+import * as storageJson from "@deepseek-ai/dsh-storage-json";
+import * as storageDomain from "@deepseek-ai/dsh-storage-domain";
+```
+
+1. `mkdtemp` 建临时 root；ctx1：依次 `ctx.plugin(Storage)`、`ctx.plugin(storageJson, { root })`、
+   `ctx.plugin(storageDomain, { backend: "json" })`、再挂本插件（无 webserver 也可——`inject` 只含
+   webServer，故 ctx1 也挂 WebServer `{ host: "127.0.0.1", port: 0 }`），保留全部 Fiber。
+2. `await` 一个小轮询（≤5s，50ms 间隔）直到 `ctx1.get("auth")!.sessions !== undefined`。
+3. `const { token } = await store.create("token", 60_000)`；断言 `getByToken(token)` 返回行；断言
+   `<root>/dsh_auth_sessions.json` 存在且内容含 digest 键（读文件、`JSON.parse`、
+   断言 `doc.tables.sessions[digest]` 存在——文件结构见 §2.2）。
+4. 逆序 dispose ctx1 全部 Fiber。
+5. ctx2：同一 root、同一栈、同样等待 sessions ready；`getByToken(token)` 返回相同 `subject` 与
+   `expiresAt`（**跨"重启"持久化成立**）。
+6. teardown：dispose + `rmSync(root, { recursive: true, force: true })`。
+
+> 若测试失败且失败原因是某 harness 包行为与本文件不符：**停下报告差异**，不要改测试去迁就。
+
+---
+
+## 6. 实施顺序（按序执行，每步保持 `npm run verify` 可绿）
+
+1. `package.json` 依赖变更 + `npm install --registry=https://registry.npmjs.org/`。
+2. `src/gate.ts` → `src/gate.test.ts`（先绿）。
+3. `src/guard.ts` → `src/guard.test.ts`。
+4. `src/session-store.ts` → `src/session-store.test.ts`。
+5. `src/self-check.ts` → `src/self-check.test.ts`。
+6. `src/index.ts`（重写，替换现有骨架）→ `src/index.test.ts`（重写）。
+7. 集成测试两个文件（最后写：依赖前五步稳定）。
+8. `docs/development.md` 的 `## Structure` 树更新为：
+   ```
+   src/
+   ├── index.ts          # plugin entry: name / inject / Config / apply + auth 服务接线
+   ├── guard.ts          # webServer 路由/升级/fallback 包装与拒绝管线
+   ├── gate.ts           # Gate 词表 + noopGate（M2 换真门）
+   ├── session-store.ts  # storage-domain 会话持久化
+   ├── self-check.ts     # 包装覆盖自检（fail loud）
+   ├── *.test.ts         # 单元测试（显式 vitest import）
+   └── integration.*.test.ts  # 真实 cordis/webserver/storage 栈集成测试
+   ```
+
+---
+
+## 7. Definition of Done（全部满足才算完成）
+
+1. `npm run verify` 全绿（format:check + lint + type-check + test:coverage ≥80% + lock:check）。
+2. `npm run build` 成功且 `lib/` 已重新生成；`git status` 中 `src/` 与 `lib/` 同批改动（AGENTS.md 提交纪律，未获指令**不 commit 不 push**）。
+3. `npm run test -- src/integration.guard.test.ts src/integration.session.test.ts` 单独跑也绿。
+4. 报告中列出：改动文件清单、每个冻结决策（D1–D16）的落点文件、覆盖率数字、任何与本文档不一致之处（应为零；有则视为未完成）。
+
+---
+
+## 8. 禁区清单（违反 = 返工）
+
+- **不探索 harness 内部**：只信本文档 §2 的事实。需要新事实 → 停下报告。
+- **不发明 API**：`webServer` 没有中间件/事件钩子；storage 只有 §2.2 列出的接口。
+- **不吞错误**：handler 错误向上抛；`open` 失败走 `log.error` 分支后守卫仍挂载（D3）。
+- **不留副作用**：所有注册（wrap、domain、provide 由 fiber 自动注销）必须有对应 effect/disposer。
+- **不写 `console.*`**（src 内 lint 报 error）；日志统一 `ctx.logger("dsh-auth")`。
+- **不落敏感值进日志/测试快照**：token 只在内存与响应中出现；测试断言用已知向量，不 print 真实随机 token。
+- **不改门禁**：不得降 coverage 阈值、不得加 eslint-disable（除文件内既有允许项）、不得改 tsconfig/eslint/vitest 配置。
+- **不改依赖之外的 package.json 字段**（version 由 release-please 管，scripts/files/exports 不动）。
+- **不动其他里程碑**：M2+（token 校验、登录页、users.yaml、TOTP、CLI、`cordis.patch.yml`/profile 行文档）不在 M1。写代码时如需要引用，只做 TODO 注释并带稳定 tag（如 `TODO(auth-token-gate):`）。
+- **分支纪律**：所有改动留在 `development`，不碰 `main`，未获指令不 commit/push。
+
+---
+
+## 9. 明确不做（M1 范围之外，勿实现）
+
+- 登录页与 `/auth/*` 端点、Bearer/token 校验、credentials 引用（M2）。
+- users.yaml / argon2id / 限速 / `dsh-auth user` CLI（M3）。
+- TOTP 两段式登录（M4）。
+- 部署侧交付物：`cordis.patch.yml` 生产 patch、profile 行文档、部署验收清单（M1 代码交付后单独做）。
+- client 半边（登出按钮等 GUI 组件）。

--- a/docs/impl-m2.md
+++ b/docs/impl-m2.md
@@ -1,116 +1,116 @@
-# dsh-auth M2 实施规格（executable spec）
+# dsh-auth M2 Implementation Spec (executable spec)
 
-> 读者：执行实现的编码代理（预期 deepseek v4 flash，**新 session**）。本文档是**决策完备的规格**：
-> 所有判断点已预先关闭，执行者只做翻译，不做设计。
-> 基线：`docs/impl-m1.md`（M1 已交付：守卫包装、自检、会话存储、auth 服务骨架——M2 在其上叠加）。
-> 设计依据：`docs/dsh-auth-plan.md` §5/§6 阶段 1/§8；工程门禁：`docs/development.md`。
-> **本文件是 M2 的唯一权威细则**；与 plan/M1 冲突时以本文件为准。
+> Readers: coding agents implementing this (expected deepseek v4 flash, **new session**). This document is a **decision-complete spec**:
+> every decision point is pre-closed; the implementer only translates, no design.
+> Baseline: `docs/impl-m1.md` (M1 delivered: guard wrapper, self-check, session store, auth service skeleton — M2 layers on top of it).
+> Design rationale: `docs/dsh-auth-plan.md` §5/§6 phase 1/§8; engineering gates: `docs/development.md`.
+> **This file is the sole authoritative spec for M2**; where it conflicts with plan/M1, this file wins.
 >
-> 环境与验证工作流见 `docs/handoff-m2.md`（新 session 必读：服务器访问、沙箱网络限制、
-> M1 踩坑清单）。**禁止自行探索 harness 内部**——需要本文件之外的事实，停下报告。
+> Environment and verification workflow: see `docs/handoff-m2.md` (a new session must read: server access, sandbox network limits,
+> M1 pitfall checklist). **Do not explore harness internals yourself** — if you need facts outside this file, stop and report.
 
 ---
 
-## 1. M2 目标
+## 1. M2 Goals
 
-把 M1 的惰性门（`noopGate` 全放行）替换为**共享 token 门**：
+Replace M1's lazy gate (`noopGate`, which allows everything) with a **shared-token gate**:
 
-- 未认证请求被守卫拒绝（HTML 导航 → 302 登录页；API/WS → 401/拒握手——M1 管线已就绪）；
-- `GET /auth/login` 自包含登录页 + `POST /auth/login` 提交 token → 恒时校验 → 发持久化会话 cookie；
-- `Authorization: Bearer <token>` 直接通过守卫（curl/脚本友好）；
-- `POST /auth/logout` 吊销会话；`GET /auth/status` 报告认证状态；其余 `/auth/*` 路径一律 404 兜底
-  （不落到 SPA fallback）。
+- Unauthenticated requests are rejected by the guard (HTML navigation → 302 login page; API/WS → 401/reject handshake — the M1 pipeline is ready);
+- `GET /auth/login` self-contained login page + `POST /auth/login` submits a token → constant-time validation → issues a persistent session cookie;
+- `Authorization: Bearer <token>` passes the guard directly (curl/script-friendly);
+- `POST /auth/logout` revokes the session; `GET /auth/status` reports authentication state; all other `/auth/*` paths fall through to a 404
+  (do not fall back to the SPA fallback).
 
-M1 的守卫/会话/自检全部复用，**不改其行为**；本里程碑只换门 + 加端点。
-
----
-
-## 2. 冻结决策表（M2 增量；M1 的 D1–D16 不变）
-
-| #   | 决策         | 冻结值                                                                                                                                                                                                                                                                                                                                       |
-| --- | ------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| M1  | gate 替换    | `apply` 用 `TokenGate` 实例替换 `noopGate`；`AuthService.gate` 字段保持可写（测试注入、M3 换门兼容）                                                                                                                                                                                                                                         |
-| M2  | token 来源   | config `tokenRef: string` = credentials 引用名（环境变量名），默认 `"DSH_AUTH_TOKEN"`；**每次 decide 经 `ctx.credentials.resolve(tokenRef)` 重新解析**（credentials 服务 per-operation 语义，改凭证无需重启）；credentials 服务缺失 → **首次解析时** `log.error` + 门**恒 deny**（fail-closed；告警惰性触发——见 §3.1 挂载竞态）              |
-| M3  | 校验方式     | 恒时比较：`crypto.timingSafeEqual(sha256(input), sha256(stored))`（双方先哈希再比较，长度恒等；`safeEqual(input, stored)` 导出可测）                                                                                                                                                                                                         |
-| M4  | 公共路径     | `TokenGate` 恒放行 `/auth` 与 `/auth/*`（常量 `AUTH_PATH_PREFIX = "/auth"` 放 `guard.ts`）；兜底前缀 + 三个 exact 端点经**包装后的** `register` 注册（被守卫包装但被 gate 放行——与 plan §5 白名单一致，自检无缺口、重启自愈；不做独立白名单配置项）                                                                                          |
-| M5  | 端点集       | `GET /auth/login`（自包含 HTML）、`POST /auth/login`（urlencoded：`token` + `next`）、`POST /auth/logout`、`GET /auth/status`（JSON `{ authenticated: boolean }`）。路由模型见 M15（3 exact + 1 prefix 兜底）；`/auth/status` **只认 cookie**（Bearer 不参与——无状态通道不建会话，不是"会话状态"）                                           |
-| M6  | 会话语义     | 登录成功 → `SessionStore.create("token", ttl)`（subject 恒 `"token"`，plan §5；**每次登录都是新会话**，防固定天然满足）；cookie 由 `buildSetCookie` 输出                                                                                                                                                                                     |
-| M7  | cookieSecure | config `cookieSecure: boolean` 默认 `true`；`false` 时 cookie 省略 `; Secure`（http 测试/开发）。`buildSetCookie` 增加可选第 4 参 `secure = true`（**向后兼容** M1 签名与测试）                                                                                                                                                              |
-| M8  | next 校验    | 必须以单个 `/` 开头、非 `//` 开头、不含 `\`；否则回落 `/`（防开放重定向）                                                                                                                                                                                                                                                                    |
-| M9  | Bearer       | `Authorization: Bearer <token>` 恒时校验通过即放行，**不建会话**；HTTP 与 upgrade 都生效（浏览器 WS 无法自定义头，cookie 是浏览器通道——文档注明）                                                                                                                                                                                            |
-| M10 | body 解析    | 仅接受 `application/x-www-form-urlencoded`（判定：取首个 `;` 前的 token，`trim().toLowerCase()` 后**全等**——不用 startsWith，会误收 `...x` 后缀）；大小上限 16 KiB（超限 413，见 M19）；`URLSearchParams` 解析；不符 415                                                                                                                     |
-| M11 | mode 语义    | `"token"`（默认）激活 TokenGate；`"password"` 在 M2 `apply` 直接抛错（fail loud；M3 实现）                                                                                                                                                                                                                                                   |
-| M12 | 依赖         | **零新增**：`node:crypto`/`URLSearchParams` 内建；credentials 服务用结构类型 `ctx.get("credentials") as unknown as CredentialRefResolver`（不 import 包类型 → 不加依赖）                                                                                                                                                                     |
-| M13 | 限速         | M2 **不做**（token 256-bit 熵足够；M3 password 流加 IP+账号限速）                                                                                                                                                                                                                                                                            |
-| M14 | CSRF         | M2 不做登录/登出 CSRF token（登录 CSRF 影响可忽略、`SameSite=Lax` 已覆盖大部分；文档注明，M3 评估）                                                                                                                                                                                                                                          |
-| M15 | 路由模型     | webserver **无 method 路由**（`exact` 表只按 pathname 建键、重复 path 抛错——实测）→ **3 条 exact 路由**（`/auth/login`、`/auth/logout`、`/auth/status`）+ **1 条 prefix 兜底**（`/auth` → 404，防未注册 `/auth/*` 落到 SPA fallback，M20）；每个 exact handler 内部按 `req.method` 分发，非白名单 method → `405` + `allow` 头 + `text/plain` |
-| M16 | 会话访问器   | `sessions` 一律以访问器 `() => SessionStore \| undefined` 注入（TokenGate 与 AuthEndpointsDeps **同形**）；`apply` 中 `auth` 对象**一步成型**：`gate: new TokenGate({ ..., sessions: () => auth.sessions })`（闭包自引用，apply 内无 await、无裸奔窗口）；`noopGate` import 移除（`gate.ts` 导出保留，测试用）                               |
-| M17 | 恒时比较     | `timingSafeEqual` **只接受 Buffer/TypedArray**（hex 字符串直接 TypeError——本机实测）→ `safeEqual` 用 `createHash("sha256").update(x).digest()`（Buffer，双方恒 32 字节），**不用** `digest("hex")`                                                                                                                                           |
-| M18 | 测试凭证     | 集成测试用**结构型假 provider**（`ctx.provide("credentials", { resolve })`，先于本插件挂载）；真实 `LocalCredentialProvider` 只在服务器冒烟（DoD 4）覆盖。**零新增依赖（含 devDependencies）**——`dsh-credentials-local` 及其 5 个 peer 包不进 package.json                                                                                   |
-| M19 | 413 处理     | 超限：停止累积、`throw { status: 413 }`；端点写 `connection: close` + `413` + `res.end()`，**不调用 `req.destroy()`**（实测：destroy 会毁掉 keep-alive，后续请求 socket hang up）                                                                                                                                                            |
-| M20 | 白名单兜底   | prefix `/auth` 兜底路由经**包装后**的 register 注册，handler 恒 404（自检计入覆盖）；`validateNext` 额外拒绝 `"/auth"` 与 `/auth/*`（回落 `/`）——防登录后 302 回环；`GET /auth/login` 恒渲染登录页（不查会话、不重定向）                                                                                                                     |
-| M21 | 端点日志     | 冻结日志事件：登录失败 `info`（"login rejected"）、登录成功 `info`（"session issued"）、503 `error`、logout `info`（"logout"）；**任何日志永不包含 token 值/session token**（`AuthEndpointsDeps.logger` 由此消费）                                                                                                                           |
-| M22 | logout 语义  | `next` 仅从 **query** 取（无则 `/`）；**不解析 body、不要求 content-type**（裸 `curl -X POST` 可用）；cookie 缺失也照常 302 + 清 cookie（幂等）                                                                                                                                                                                              |
+All of M1's guard/session/self-check functionality is reused, **its behavior unchanged**; this milestone only swaps the gate and adds endpoints.
 
 ---
 
-## 3. 权威契约（M2 新增；其余见 impl-m1.md §2）
+## 2. Frozen Decision Table (M2 increments; M1's D1–D16 unchanged)
 
-### 3.1 credentials 服务（`@deepseek-ai/dsh-credentials@0.1.0-rc.6` + `dsh-credentials-local`）
+| #   | Decision           | Frozen value                                                                                                                                                                                                                                                                                                                                                                                                                         |
+| --- | ------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| M1  | gate swap          | `apply` replaces `noopGate` with a `TokenGate` instance; the `AuthService.gate` field stays writable (for test injection, M3 gate-swap compatibility)                                                                                                                                                                                                                                                                                |
+| M2  | token source       | config `tokenRef: string` = credentials reference name (environment variable name), default `"DSH_AUTH_TOKEN"`; **re-resolve via `ctx.credentials.resolve(tokenRef)` on every decide** (credentials service per-operation semantics, changing credentials requires no restart); credentials service missing → **on first resolve** `log.error` + gate **always denies** (fail-closed; warning triggers lazily — see §3.1 mount race) |
+| M3  | validation         | constant-time comparison: `crypto.timingSafeEqual(sha256(input), sha256(stored))` (hash both sides then compare, equal length always; `safeEqual(input, stored)` exported, testable)                                                                                                                                                                                                                                                 |
+| M4  | public paths       | `TokenGate` always allows `/auth` and `/auth/*` (constant `AUTH_PATH_PREFIX = "/auth"` in `guard.ts`); the fallback prefix + three exact endpoints registered via the **wrapped** `register` (wrapped by the guard but allowed by the gate — consistent with plan §5 whitelist, self-check has no gaps, self-heals on restart; no separate whitelist config item)                                                                    |
+| M5  | endpoint set       | `GET /auth/login` (self-contained HTML), `POST /auth/login` (urlencoded: `token` + `next`), `POST /auth/logout`, `GET /auth/status` (JSON `{ authenticated: boolean }`). Routing model per M15 (3 exact + 1 prefix fallback); `/auth/status` **only honors cookies** (Bearer does not participate — the stateless channel creates no session, it is not "session state")                                                             |
+| M6  | session semantics  | login success → `SessionStore.create("token", ttl)` (subject always `"token"`, plan §5; **every login is a new session**, session-fixation defense naturally satisfied); cookie output via `buildSetCookie`                                                                                                                                                                                                                          |
+| M7  | cookieSecure       | config `cookieSecure: boolean` default `true`; when `false` the cookie omits `; Secure` (http testing/dev). `buildSetCookie` gains an optional 4th param `secure = true` (**backward compatible** with the M1 signature and tests)                                                                                                                                                                                                   |
+| M8  | next validation    | must start with a single `/`, must not start with `//`, must not contain `\`; otherwise fall back to `/` (anti-open-redirect)                                                                                                                                                                                                                                                                                                        |
+| M9  | Bearer             | `Authorization: Bearer <token>` passes on successful constant-time validation, **creates no session**; effective for both HTTP and upgrade (browser WebSockets cannot set custom headers, cookie is the browser channel — note in docs)                                                                                                                                                                                              |
+| M10 | body parsing       | only accepts `application/x-www-form-urlencoded` (check: take the token before the first `;`, `trim().toLowerCase()` then **exact equality** — do not use startsWith, it would wrongly accept `...x` suffixes); size cap 16 KiB (over-limit 413, see M19); `URLSearchParams` parsing; non-matching 415                                                                                                                               |
+| M11 | mode semantics     | `"token"` (default) activates TokenGate; `"password"` in M2 `apply` throws directly (fail loud; M3 implements it)                                                                                                                                                                                                                                                                                                                    |
+| M12 | dependencies       | **zero new**: `node:crypto`/`URLSearchParams` builtin; credentials service used via structural type `ctx.get("credentials") as unknown as CredentialRefResolver` (no import of package types → no added dependency)                                                                                                                                                                                                                  |
+| M13 | rate limiting      | M2 **does not do it** (token 256-bit entropy is sufficient; M3 password flow adds IP+account rate limiting)                                                                                                                                                                                                                                                                                                                          |
+| M14 | CSRF               | M2 does no login/logout CSRF token (login CSRF impact is negligible, `SameSite=Lax` covers most; note in docs, M3 evaluates)                                                                                                                                                                                                                                                                                                         |
+| M15 | routing model      | webserver has **no method routing** (the `exact` table keys only by pathname, duplicate paths throw — tested) → **3 exact routes** (`/auth/login`, `/auth/logout`, `/auth/status`) + **1 prefix fallback** (`/auth` → 404, to prevent unregistered `/auth/*` falling to the SPA fallback, M20); each exact handler dispatches internally by `req.method`, non-whitelisted method → `405` + `allow` header + `text/plain`             |
+| M16 | session accessor   | `sessions` is always injected as an accessor `() => SessionStore                                                                                                                                                                                                                                                                                                                                                                     | undefined`(TokenGate and AuthEndpointsDeps are **isomorphic**); the`auth`object in`apply`is built **in one step**:`gate: new TokenGate({ ..., sessions: () => auth.sessions })`(closure self-reference, no await inside apply, no bare window);`noopGate` import removed (`gate.ts` export kept, for tests) |
+| M17 | constant-time      | `timingSafeEqual` **only accepts Buffer/TypedArray** (hex string throws TypeError directly — verified locally) → `safeEqual` uses `createHash("sha256").update(x).digest()` (Buffer, both sides always 32 bytes), **do not** use `digest("hex")`                                                                                                                                                                                     |
+| M18 | test credentials   | integration tests use a **structural fake provider** (`ctx.provide("credentials", { resolve })`, mounted before this plugin); the real `LocalCredentialProvider` is covered only in server smoke tests (DoD 4). **Zero new dependencies (including devDependencies)** — `dsh-credentials-local` and its 5 peer packages do not go into package.json                                                                                  |
+| M19 | 413 handling       | over-limit: stop accumulating, `throw { status: 413 }`; endpoint writes `connection: close` + `413` + `res.end()`, **does not call `req.destroy()`** (verified: destroy kills keep-alive, subsequent requests socket hang up)                                                                                                                                                                                                        |
+| M20 | whitelist fallback | the prefix `/auth` fallback route is registered via the **wrapped** register, handler always 404 (self-check counts coverage); `validateNext` also rejects `"/auth"` and `/auth/*` (fall back `/`) — prevent 302 loop after login; `GET /auth/login` always renders the login page (no session check, no redirect)                                                                                                                   |
+| M21 | endpoint logging   | frozen log events: login failure `info` ("login rejected"), login success `info` ("session issued"), 503 `error`, logout `info` ("logout"); **any log never contains the token value/session token** (consumed by `AuthEndpointsDeps.logger`)                                                                                                                                                                                        |
+| M22 | logout semantics   | `next` is taken **only from the query** (else `/`); **does not parse body, requires no content-type** (bare `curl -X POST` works); missing cookie still 302 + clears cookie (idempotent)                                                                                                                                                                                                                                             |
 
-- **web 组合自带**：`dsh-base` bundle 的 `credentials` 行 = `@deepseek-ai/dsh-credentials-local`（读
-  `$DSH_HOME/.credentials.yaml`，env 层优先于文件层；**每次 resolve 重新读取**，改文件无需重启）。
-- **挂载竞态（实测）**：harness **并行挂载行**——credentials 行（dsh-base）可能在本插件（用户层）
-  apply **之后**才就绪（服务器冒烟实测：apply 时 `ctx.get("credentials") === undefined`，数秒后
-  可见）。因此解析器**每次 resolve 惰性 `ctx.get("credentials")`**（§4.6 item 3），缺失告警也在
-  首次解析时触发——既是 M2 的 per-operation 语义，也天然规避竞态（M2 行冻结值已同步修订）。
-- 服务面：`ctx.credentials.resolve(ref): Promise<{ value: string; source: string } | undefined>`
-  （ref 是环境变量名形式的字符串；未配置 → `undefined`）。我们**不 import 包类型**，用结构类型：
+---
+
+## 3. Authoritative Contracts (M2 additions; the rest per impl-m1.md §2)
+
+### 3.1 credentials service (`@deepseek-ai/dsh-credentials@0.1.0-rc.6` + `dsh-credentials-local`)
+
+- **Web composition includes it by default**: the `credentials` line of the `dsh-base` bundle = `@deepseek-ai/dsh-credentials-local` (reads
+  `$DSH_HOME/.credentials.yaml`, env layer takes precedence over file layer; **re-read on every resolve**, changing the file requires no restart).
+- **Mount race (verified)**: the harness **mounts lines in parallel** — the credentials line (dsh-base) may become ready only **after** this plugin (user layer)
+  applies (server smoke tested: at apply time `ctx.get("credentials") === undefined`, visible a few seconds
+  later). Therefore the resolver **lazily `ctx.get("credentials")` on every resolve** (§4.6 item 3); the missing warning is
+  also triggered on first resolve — which is both M2's per-operation semantics and a natural avoidance of the race (M2 row frozen value already amended in sync).
+- Service surface: `ctx.credentials.resolve(ref): Promise<{ value: string; source: string } | undefined>`
+  (ref is a string in environment-variable name form; not configured → `undefined`). We **do not import package types**, we use a structural type:
   ```ts
   interface CredentialRefResolver {
     resolve(ref: string): Promise<{ value: string; source: string } | undefined>;
   }
   ```
-- 本插件**只读**凭证，不 set/unset。`CredentialRefResolver` 结构接口声明在 `src/index.ts`
-  （私有，不导出）。
-- `dsh-credentials-local` 是类插件（named export `LocalCredentialProvider`，Config 含 `path?`）：
-  服务器冒烟直接复用 web 组合自带的 `credentials` 行，写 `$DSH_HOME/.credentials.yaml`。
-  **文件权限必须 0600**：`assertOwnerOnly` 在文件存在且 group/other 可读时启动即抛错
-  （`chmod 600`）。**集成测试不挂真实 provider**（M18：零新增依赖）——用结构型假 provider
-  `ctx.provide("credentials", { resolve })` 先于本插件挂载；真实 provider 的 env 层优先语义
-  （`process.env[tokenRef]` 可直接供冒烟）在服务器侧验证。
-- 服务缺失（首次解析时 `ctx.get("credentials") === undefined`，惰性）：`log.error("credentials
-service is unavailable: gate denies everything (fail-closed)")` 一次；`TokenGate` 的 resolver
-  返回 `undefined` → 所有凭证校验失败 → 恒 deny（但白名单 `/auth/*` 仍放行，登录页可见、登录
-  不可用——可诊断）。
+- This plugin is **read-only** for credentials; it does not set/unset. The `CredentialRefResolver` structural interface is declared in `src/index.ts`
+  (private, not exported).
+- `dsh-credentials-local` is a plugin-like package (named export `LocalCredentialProvider`, Config contains `path?`):
+  the server smoke test directly reuses the web composition's built-in `credentials` line and writes `$DSH_HOME/.credentials.yaml`.
+  **The file permissions must be 0600**: `assertOwnerOnly` throws at startup if the file exists and is group/other-readable
+  (`chmod 600`). **Integration tests do not mount a real provider** (M18: zero new dependencies) — use a structural fake provider
+  `ctx.provide("credentials", { resolve })` mounted before this plugin; the real provider's env-layer-precedence semantics
+  (`process.env[tokenRef]` can be supplied directly for smoke tests) are verified server-side.
+- Service missing (at first resolve `ctx.get("credentials") === undefined`, lazy): `log.error("credentials
+service is unavailable: gate denies everything (fail-closed)")` once; `TokenGate`'s resolver
+  returns `undefined` → all credential validations fail → always deny (but the whitelist `/auth/*` still passes, login page visible, login
+  unavailable — diagnosable).
 
-### 3.2 node 内建（本包静态形态，均可用）
+### 3.2 node builtins (static shape of this package, all available)
 
-- `node:crypto`：`randomBytes`（M1 已用）、`createHash("sha256")`、`timingSafeEqual`。
-- `URLSearchParams`（global，Node ≥ 22）：解析 urlencoded body 与构造 query。
-- `req` 流读取：`for await (const chunk of req)` 累积，超限即断（413，M19）。
-- `timingSafeEqual(a, b)` 只接受 Buffer/TypedArray/DataView——hex 字符串直接抛 TypeError（本机
-  实测）；`safeEqual` 内部一律 `digest()`（Buffer，M17），不用 `digest("hex")`。
+- `node:crypto`: `randomBytes` (already used in M1), `createHash("sha256")`, `timingSafeEqual`.
+- `URLSearchParams` (global, Node ≥ 22): parses the urlencoded body and builds the query.
+- `req` stream reading: `for await (const chunk of req)` accumulates, breaks on over-limit (413, M19).
+- `timingSafeEqual(a, b)` accepts only Buffer/TypedArray/DataView — a hex string throws TypeError directly (verified
+  locally); inside `safeEqual` always `digest()` (Buffer, M17), do not use `digest("hex")`.
 
 ---
 
-## 4. 文件蓝图
+## 4. File Blueprints
 
-每个文件 ≤250 行、函数 ≤80 行、复杂度 ≤15（ESLint error）。M1 文件只增改三处：`session-store.ts`
-（`buildSetCookie` 加参）、`guard.ts`（仅新增 `AUTH_PATH_PREFIX` 常量，行为不变）、`src/index.ts`
-（装配）。**gate/self-check 不动**（`gate.ts` 的 `noopGate` 保留导出——测试仍用；`GuardKind`/`Gate` 不变）。
+Each file ≤250 lines, function ≤80 lines, complexity ≤15 (ESLint error). M1 files change in only three places: `session-store.ts`
+(`buildSetCookie` gains a param), `guard.ts` (only adds the `AUTH_PATH_PREFIX` constant, behavior unchanged), `src/index.ts`
+(assembly). **gate/self-check unchanged** (`noopGate` in `gate.ts` keeps its export — tests still use it; `GuardKind`/`Gate` unchanged).
 
-### 4.1 `src/cookie.ts` —— 请求 Cookie 头解析
+### 4.1 `src/cookie.ts` — Request Cookie header parsing
 
 ```ts
-/** 从 Cookie 头解析指定名字的值；同名取首个。无头/无此名 → undefined。 */
+/** Parse a named value from a Cookie header; the name is matched, first occurrence wins. No header/no such name → undefined. */
 export function parseCookieHeader(header: string | undefined, name: string): string | undefined;
 ```
 
-行为约定：`split(";")` → 每段 `trim()` → 首个 `"="` 切分 → 名字精确匹配。值不去引号（token 无引号）。
-空值返回 `""`（调用方自行判定）。纯函数，导出测试。
+Behavior contract: `split(";")` → each segment `trim()` → split on first `"="` → exact name match. Value is not unquoted (token has no quotes).
+Empty value returns `""` (caller decides). Pure function, exported for testing.
 
-### 4.2 `src/token-gate.ts` —— 共享 token 门
+### 4.2 `src/token-gate.ts` — Shared token gate
 
 ```ts
 import type { IncomingMessage } from "node:http";
@@ -121,15 +121,15 @@ import { AUTH_PATH_PREFIX } from "./guard.js";
 import { parseCookieHeader } from "./cookie.js";
 
 /**
- * 恒时比较：双方 sha256 Buffer 摘要后 timingSafeEqual（M17：timingSafeEqual 只接受
- * Buffer/TypedArray——hex 字符串直接 TypeError；Buffer 摘要双方恒 32 字节，无长度侧信道）。
+ * Constant-time comparison: timingSafeEqual on the sha256 Buffer digest of both sides (M17: timingSafeEqual only accepts
+ * Buffer/TypedArray — a hex string throws TypeError directly; Buffer digests on both sides are always 32 bytes, no length side channel).
  */
 export function safeEqual(input: string, stored: string): boolean;
 
 export interface TokenGateOptions {
-  /** 每次 decide 调用的凭证解析器（index.ts 注入 credentials.resolve 闭包）。 */
+  /** Credential resolver called on every decide (index.ts injects the credentials.resolve closure). */
   resolveToken: () => Promise<string | undefined>;
-  /** 会话访问器（M16）：每次 decide 现取——domain 异步就绪；undefined = cookie 通道不可用。 */
+  /** Session accessor (M16): fetched fresh on every decide — the domain is async-ready; undefined = cookie channel unavailable. */
   sessions: () => SessionStore | undefined;
   cookieName: string;
 }
@@ -140,52 +140,52 @@ export class TokenGate implements Gate {
 }
 ```
 
-`decide` 顺序（照此实现）：
+`decide` order (implement in this order):
 
-1. `pathname === AUTH_PATH_PREFIX || pathname.startsWith(AUTH_PATH_PREFIX + "/")` → `"allow"`。
-2. cookie：`parseCookieHeader(req.headers.cookie, this.cookieName)` → 非空
-   （`!== undefined && !== ""`）且 `this.sessions()?.getByToken(token) !== undefined` → `"allow"`
-   （`sessions()` 返回 undefined 则跳过此通道）。
-3. Bearer：`req.headers.authorization` 匹配 `/^Bearer\s+(.+)$/i` → `await this.resolveToken()` →
-   存在且 `safeEqual(bearer, stored)` → `"allow"`。
-4. 否则 `"deny"`。
+1. `pathname === AUTH_PATH_PREFIX || pathname.startsWith(AUTH_PATH_PREFIX + "/")` → `"allow"`.
+2. cookie: `parseCookieHeader(req.headers.cookie, this.cookieName)` → non-empty
+   (`!== undefined && !== ""`) and `this.sessions()?.getByToken(token) !== undefined` → `"allow"`
+   (if `sessions()` returns undefined, skip this channel).
+3. Bearer: `req.headers.authorization` matches `/^Bearer\s+(.+)$/i` → `await this.resolveToken()` →
+   exists and `safeEqual(bearer, stored)` → `"allow"`.
+4. Otherwise `"deny"`.
 
-错误语义（fail-closed）：`resolveToken` 抛错 → 本门 catch 后返回 `"deny"`（不向上抛、不打日志；
-index.ts 的 resolver 已自行 catch 并记日志——生产路径不会抛到此处，本 catch 是防御性双保险）。
+Error semantics (fail-closed): `resolveToken` throws → this gate catches and returns `"deny"` (does not rethrow, does not log;
+index.ts's resolver already catches and logs itself — the production path will not throw to here, this catch is a defensive second line).
 
-### 4.3 `src/form-body.ts` —— urlencoded 表单体读取
+### 4.3 `src/form-body.ts` — urlencoded form body reader
 
 ```ts
 import type { IncomingMessage } from "node:http";
 
 export const FORM_BODY_LIMIT = 16 * 1024;
 
-/** 读取并解析 urlencoded 请求体。返回 415（content-type 不符）/ 413（超限）时抛出带 status 的错误。 */
+/** Read and parse a urlencoded request body. Throws an error carrying a status on 415 (content-type mismatch) / 413 (over limit). */
 export async function parseFormBody(req: IncomingMessage): Promise<URLSearchParams>;
 ```
 
-行为约定：`content-type` 判定取首个 `;` 前的 token，`trim().toLowerCase()` 后**全等**
-`application/x-www-form-urlencoded`（M10：不用 startsWith，会误收 `...x` 后缀），不符
-`throw Object.assign(new Error("unsupported media type"), { status: 415 })`；
-`for await` 累积 chunks，总量 > `FORM_BODY_LIMIT` 时停止累积并
-`throw ... { status: 413 }`（**不调用 `req.destroy()`**，M19）；`new URLSearchParams(decoded)` 解析。
-错误对象带 `status` 字段——auth-endpoints 据此写响应；**不带 `status` 的流异常（abort 等）不捕获，
-向上抛**（webserver 统一 warn + 400，与守卫纪律一致）。
+Behavior contract: the `content-type` check takes the token before the first `;`, `trim().toLowerCase()` then **exact equality**
+with `application/x-www-form-urlencoded` (M10: do not use startsWith, it would wrongly accept `...x` suffixes); on mismatch
+`throw Object.assign(new Error("unsupported media type"), { status: 415 })`;
+`for await` accumulates chunks; when the total exceeds `FORM_BODY_LIMIT`, stop accumulating and
+`throw ... { status: 413 }` (**do not call `req.destroy()`**, M19); parse via `new URLSearchParams(decoded)`.
+The error object carries a `status` field — auth-endpoints writes the response from it; **stream exceptions without a `status` (abort, etc.) are not caught, but
+rethrown** (webserver uniformly warns + 400, consistent with guard discipline).
 
-### 4.4 `src/login-page.ts` —— 自包含登录页
+### 4.4 `src/login-page.ts` — Self-contained login page
 
 ```ts
-/** 渲染自包含登录页（内联样式，零第三方资源）。next/error 全部 HTML-escape。 */
+/** Render a self-contained login page (inline styles, zero third-party resources). next/error are all HTML-escaped. */
 export function loginPageHtml(next: string, error?: string): string;
 ```
 
-行为约定：`<!doctype html>` + `lang="en"`；内联 `<style>`（基础居中卡片样式，light 即可，不引外部字体）；
-`<form method="post" action="/auth/login">`；hidden `next`（escape 后）；`<input type="password" name="token"
-autocomplete="current-password" required autofocus>`；`<button type="submit">Unlock</button>`；
-`error` 非空时渲染 `<p class="error">`（escape）。HTML-escape helper 为本文件私有
-（`& < > " '` 五个字符），导出仅 `loginPageHtml`。
+Behavior contract: `<!doctype html>` + `lang="en"`; inline `<style>` (basic centered card style, light is enough, no external fonts);
+`<form method="post" action="/auth/login">`; hidden `next` (escaped); `<input type="password" name="token"
+autocomplete="current-password" required autofocus>`; `<button type="submit">Unlock</button>`;
+render `<p class="error">` when `error` is non-empty (escaped). The HTML-escape helper is private to this file
+(five characters `& < > " '`); only `loginPageHtml` is exported.
 
-### 4.5 `src/auth-endpoints.ts` —— /auth 兜底 + 三个端点
+### 4.5 `src/auth-endpoints.ts` — /auth fallback + three endpoints
 
 ```ts
 import { AUTH_PATH_PREFIX, type HttpHandler } from "./guard.js";
@@ -195,84 +195,84 @@ import { loginPageHtml } from "./login-page.js";
 import { parseCookieHeader } from "./cookie.js";
 
 export interface AuthEndpointsDeps {
-  /** 注册路由（index.ts 传入包装后的 server.register；被守卫包装但被 gate 白名单放行）。 */
+  /** Route registration (index.ts passes the wrapped server.register; wrapped by the guard but allowed by the gate whitelist). */
   register(route: { kind: "exact" | "prefix"; path: string; handler: HttpHandler }): () => void;
-  /** 会话访问器（M16）：domain 异步就绪，端点内每次现取。 */
+  /** Session accessor (M16): the domain is async-ready, fetched fresh inside the endpoints. */
   sessions: () => SessionStore | undefined;
   cookieName: string;
   cookieSecure: boolean;
-  sessionTtl: number; // 秒
-  validateToken: (token: string) => Promise<boolean>; // 恒时校验（index.ts 注入 safeEqual 闭包）
+  sessionTtl: number; // seconds
+  validateToken: (token: string) => Promise<boolean>; // constant-time validation (index.ts injects the safeEqual closure)
   logger: { error(message: unknown): void; info(message: unknown): void };
 }
 
-/** 注册 prefix `/auth` 兜底 + 三个 exact 端点；返回合并 disposer（内部收集每个 register 的 disposer）。 */
+/** Register the prefix `/auth` fallback + three exact endpoints; returns a combined disposer (collects each register's disposer internally). */
 export function registerAuthEndpoints(deps: AuthEndpointsDeps): () => void;
 ```
 
-路由模型（M15：webserver 无 method 路由——`exact` 表只按 pathname 建键、重复 path 抛错，故
-GET/POST `/auth/login` **不能**注册两条 exact 路由）：
+Routing model (M15: webserver has no method routing — the `exact` table keys only by pathname, duplicate paths throw, so
+GET/POST `/auth/login` **cannot** register two exact routes):
 
-- **prefix `AUTH_PATH_PREFIX`（= `"/auth"`，兜底，M20）**：恒 `404` + `content-type: text/plain` +
-  no-store——未注册的 `/auth/*` 不得落到 SPA fallback（exact 优先于 prefix，不遮蔽下面三个端点）。
-  路由 path 用 `AUTH_PATH_PREFIX` 常量（本节 import 的唯一消费方）。
-- **exact `/auth/login`**：handler 内按 `req.method` 分发：
-  - `GET`：`next = validateNext(query.get("next") ?? "/")` → `200` +
-    `content-type: text/html; charset=utf-8` + `cache-control: no-store` + `loginPageHtml(next)`。
-    **恒渲染登录页**（不查会话、不重定向——M20）。
-  - `POST`：`parseFormBody(req)`——带 `status` 的错误 → 对应 status + `text/plain` 消息
-    （413 额外先 `res.setHeader("connection", "close")`，M19）；**不带 `status` 的异常向上抛**
-    （webserver 统一 warn + 400）；`token = params.get("token") ?? ""`；
-    `next = validateNext(params.get("next") ?? "/")`；
-    `await deps.validateToken(token)` 失败 → `401` + `text/plain` `"invalid token"` +
-    `cache-control: no-store` + `logger.info("login rejected")`；
-    成功 → `const store = deps.sessions(); store === undefined` → `503` + `text/plain`
+- **prefix `AUTH_PATH_PREFIX` (= `"/auth"`, fallback, M20)**: always `404` + `content-type: text/plain` +
+  no-store — unregistered `/auth/*` must not fall to the SPA fallback (exact takes precedence over prefix, does not shadow the three endpoints below).
+  The route path uses the `AUTH_PATH_PREFIX` constant (the sole consumer of this import in this section).
+- **exact `/auth/login`**: handler dispatches by `req.method`:
+  - `GET`: `next = validateNext(query.get("next") ?? "/")` → `200` +
+    `content-type: text/html; charset=utf-8` + `cache-control: no-store` + `loginPageHtml(next)`.
+    **Always renders the login page** (no session check, no redirect — M20).
+  - `POST`: `parseFormBody(req)` — error with a `status` → the corresponding status + `text/plain` message
+    (for 413 first additionally `res.setHeader("connection", "close")`, M19); **exceptions without a `status` are rethrown**
+    (webserver uniformly warns + 400); `token = params.get("token") ?? ""`;
+    `next = validateNext(params.get("next") ?? "/")`;
+    `await deps.validateToken(token)` fails → `401` + `text/plain` `"invalid token"` +
+    `cache-control: no-store` + `logger.info("login rejected")`;
+    success → `const store = deps.sessions(); store === undefined` → `503` + `text/plain`
     `"session store unavailable"` + no-store + `logger.error("login failed: session store unavailable")`
-    （fail-closed，不静默放行）；否则
-    `const { token: sessionToken } = await store.create("token", deps.sessionTtl * 1000)`；
-    `res.setHeader("set-cookie", buildSetCookie(deps.cookieName, sessionToken, deps.sessionTtl, deps.cookieSecure))`；
+    (fail-closed, does not silently allow); otherwise
+    `const { token: sessionToken } = await store.create("token", deps.sessionTtl * 1000)`;
+    `res.setHeader("set-cookie", buildSetCookie(deps.cookieName, sessionToken, deps.sessionTtl, deps.cookieSecure))`;
     `res.writeHead(302, { location: next }); res.end();` + `logger.info("session issued")`
-    （全程 no-store）。
-  - 其他 method → `405` + `allow: GET, POST` + `text/plain`（no-store）。
-- **exact `/auth/logout`**：仅 `POST`（其他 → `405` + `allow: POST`）：
-  `next = validateNext(query.get("next") ?? "/")`（M22：next 仅从 query 取；
-  **不解析 body、不要求 content-type**——裸 `curl -X POST` 可用）；
+    (no-store throughout).
+  - Any other method → `405` + `allow: GET, POST` + `text/plain` (no-store).
+- **exact `/auth/logout`**: `POST` only (any other → `405` + `allow: POST`):
+  `next = validateNext(query.get("next") ?? "/")` (M22: `next` is taken only from the query;
+  **does not parse body, requires no content-type** — bare `curl -X POST` works);
   `const store = deps.sessions(); const token = parseCookieHeader(req.headers.cookie, deps.cookieName);`
-  `token` 非空（`!== undefined && !== ""`）且 `store !== undefined` →
-  `await store.revokeByToken(token)`（无会话/无 cookie 静默成功）；
-  `res.setHeader("set-cookie", buildSetCookie(deps.cookieName, "", 0, deps.cookieSecure))`（Max-Age=0 清除）；
-  `res.writeHead(302, { location: next }); res.end();` + `logger.info("logout")`；no-store。
-- **exact `/auth/status`**：仅 `GET`（其他 → `405` + `allow: GET`）：
-  只认 cookie（M5：Bearer 不参与——无状态通道不建会话，不是"会话状态"）：
+  `token` non-empty (`!== undefined && !== ""`) and `store !== undefined` →
+  `await store.revokeByToken(token)` (no session/no cookie silently succeeds);
+  `res.setHeader("set-cookie", buildSetCookie(deps.cookieName, "", 0, deps.cookieSecure))` (Max-Age=0 clears);
+  `res.writeHead(302, { location: next }); res.end();` + `logger.info("logout")`; no-store.
+- **exact `/auth/status`**: `GET` only (any other → `405` + `allow: GET`):
+  only honours cookies (M5: Bearer does not participate — the stateless channel creates no session, it is not "session state"):
   `const store = deps.sessions(); const token = parseCookieHeader(req.headers.cookie, deps.cookieName);`
   `const authenticated = store !== undefined && token !== undefined && token !== "" &&
 store.getByToken(token) !== undefined;`
-  → `200` + `application/json` + `JSON.stringify({ authenticated })` + no-store。
+  → `200` + `application/json` + `JSON.stringify({ authenticated })` + no-store.
 
-`validateNext` 为本文件私有导出：`next` 以单个 `/` 开头
-（`next.startsWith("/") && !next.startsWith("//") && !next.includes("\\")`）**且**
-`next !== "/auth"`、`!next.startsWith("/auth/")`（M20：拒 /auth* 防登录后 302 回环）→ 原样；否则 `"/"`。
-`req.url` 的 query 解析用 `new URL(req.url ?? "/", "http://x")`（与守卫一致）。
-全部端点响应带 `cache-control: no-store`；日志事件见 M21（任何日志**永不**包含 token 值/session token）。
+`validateNext` is a private export of this file: `next` starts with a single `/`
+(`next.startsWith("/") && !next.startsWith("//") && !next.includes("\\")`) **and**
+`next !== "/auth"`, `!next.startsWith("/auth/")` (M20: reject /auth* to prevent a 302 loop after login) → return as-is; otherwise `"/"`.
+The `req.url` query is parsed with `new URL(req.url ?? "/", "http://x")` (consistent with the guard).
+All endpoint responses carry `cache-control: no-store`; log events per M21 (any log **never** contains the token value/session token).
 
-### 4.6 `src/index.ts` —— 装配变更（其余 M1 逻辑不动）
+### 4.6 `src/index.ts` — assembly changes (remaining M1 logic unchanged)
 
-1. `Config` 增加两字段（默认值进 schemastery）：
+1. `Config` gains two fields (defaults go into schemastery):
    ```ts
    tokenRef: z.string().pattern(/^[A-Za-z_][A-Za-z0-9_]*$/).default("DSH_AUTH_TOKEN"),
    cookieSecure: z.boolean().default(true),
    ```
-   （`pattern` 与 dsh-credentials 的 credential-ref 模式一致，同时挡住空串。）
-   `AuthConfig` 接口同步（`mode`/`sessionTtl`/`cookieName` 不变）。
-2. `apply` 开头：`if (config.mode === "password") throw new Error("dsh-auth: password flow requires M3 (not implemented in M2)");`（在 `void config` 处改为真正使用 config）。
-3. credentials 解析器（替换 M1 的 `void config`）——**惰性取服务**（§3.1 挂载竞态：credentials 行
-   可能在本行 apply 之后才就绪，每次 resolve 现取 `ctx.get("credentials")`）：
+   (the `pattern` matches dsh-credentials' credential-ref pattern and also blocks empty strings.)
+   `AuthConfig` interface updated in sync (`mode`/`sessionTtl`/`cookieName` unchanged).
+2. At the start of `apply`: `if (config.mode === "password") throw new Error("dsh-auth: password flow requires M3 (not implemented in M2)");` (at `void config`, change to actually using config).
+3. credentials resolver (replaces M1's `void config`) — **fetch the service lazily** (§3.1 mount race: the credentials line
+   may become ready only after this line applies; fetch `ctx.get("credentials")` fresh on every resolve):
    ```ts
-   /** credentials 服务的结构镜像（§3.1）；本文件私有，不导出。 */
+   /** Structural mirror of the credentials service (§3.1); private to this file, not exported. */
    interface CredentialRefResolver {
      resolve(ref: string): Promise<{ value: string; source: string } | undefined>;
    }
-   /** 返回 resolveToken；服务缺失告警只在首次解析时触发一次（fail-closed，可诊断）。 */
+   /** Returns resolveToken; the missing-service warning fires only once on first resolve (fail-closed, diagnosable). */
    function makeTokenResolver(
      ctx: Context,
      config: AuthConfig,
@@ -295,31 +295,31 @@ store.getByToken(token) !== undefined;`
          log.error(
            `token resolution failed: ${error instanceof Error ? error.message : String(error)}`,
          );
-         return undefined; // fail-closed：解析失败 = 无凭证
+         return undefined; // fail-closed: resolution failure = no credentials
        }
      };
    }
    ```
-4. 装配门（M16）：替换 M1 第 3 步的 `{ sessions: undefined, gate: noopGate }`，`auth` 对象**一步成型**：
+4. Gate assembly (M16): replace M1 step 3's `{ sessions: undefined, gate: noopGate }`; the `auth` object is built **in one step**:
    ```ts
    const auth: AuthService = {
      sessions: undefined,
      gate: new TokenGate({
        resolveToken,
-       sessions: () => auth.sessions, // 访问器闭包自引用 auth（domain 异步就绪后由 open 回调赋值）
+       sessions: () => auth.sessions, // accessor closure self-references auth (assigned by the open callback once the domain is async-ready)
        cookieName: config.cookieName,
      }),
    };
    ctx.provide("auth", auth);
    ```
-   顺序：log → credentials/resolveToken → auth → provide；apply 内无 await、无裸奔窗口。闭包自引用
-   合法（`decide` 时才求值）。`noopGate` 的 import 移除（`gate.ts` 导出保留，测试用）。
-5. 端点注册（在 wrapServer 与自检之间；`safeEqual` 从 `./token-gate.js` import）：
+   Order: log → credentials/resolveToken → auth → provide; no await inside apply, no bare window. The closure self-reference is valid
+   (only evaluated at `decide` time). Remove the `noopGate` import (`gate.ts` export kept, for tests).
+5. Endpoint registration (between wrapServer and self-check; `safeEqual` imported from `./token-gate.js`):
    ```ts
    ctx.effect(
      () =>
        registerAuthEndpoints({
-         register: (route) => server.register(route), // 包装后的 register（增量保险路径）
+         register: (route) => server.register(route), // wrapped register (incremental insurance path)
          sessions: () => auth.sessions,
          cookieName: config.cookieName,
          cookieSecure: config.cookieSecure,
@@ -333,138 +333,138 @@ store.getByToken(token) !== undefined;`
      "dsh-auth: auth endpoints",
    );
    ```
-   自检在端点注册**之后**执行（端点也计入覆盖）。
-6. 移除对 `noopGate` 的 import（gate.ts 导出保留，测试用）。
+   The self-check runs **after** endpoint registration (the endpoints also count toward coverage).
+6. Remove the `noopGate` import (the gate.ts export is kept, for tests).
 
-### 4.7 `src/session-store.ts` —— 一处向后兼容修改
+### 4.7 `src/session-store.ts` — one backward-compatible change
 
-`buildSetCookie` 增加第 4 参：`secure: boolean = true`；`false` 时输出省略 `; Secure`：
+`buildSetCookie` gains a 4th param: `secure: boolean = true`; when `false` the output omits `; Secure`:
 `${cookieName}=${token}; Max-Age=${maxAgeSeconds}; Path=/; HttpOnly; ${secure ? "Secure; " : ""}SameSite=Lax`
-（注意空格：`Path=/; HttpOnly; Secure; SameSite=Lax` 与 `Path=/; HttpOnly; SameSite=Lax` 都要精确）。
+(note the spacing: `Path=/; HttpOnly; Secure; SameSite=Lax` and `Path=/; HttpOnly; SameSite=Lax` must both be exact).
 
 ---
 
-## 5. 测试矩阵
+## 5. Test Matrix
 
-M1 测试**全保留**；`src/index.test.ts` 按 §4.6 适配（gate 是 TokenGate 实例、mode=password 抛错、
-credentials 缺失 → resolver 恒 undefined + error 日志、storageDomain 与 credentials 双缺失 → 2 条
-error 日志、Config 默认值补 `tokenRef`/`cookieSecure`、fake ctx 增加 `credentials` 分支）。新增：
+All M1 tests **kept**; `src/index.test.ts` adapted per §4.6 (gate is a TokenGate instance, mode=password throws,
+credentials missing → resolver always undefined + error log, both storageDomain and credentials missing → 2
+error logs, Config defaults add `tokenRef`/`cookieSecure`, fake ctx adds a `credentials` branch). Additions:
 
-**`src/cookie.test.ts`** — 无头 → undefined；单 cookie；多 cookie 取同名首个；值含 `=`；带空格/引号容错；名不存在 → undefined。
+**`src/cookie.test.ts`** — no header → undefined; single cookie; multiple cookies, first occurrence of the matching name; value containing `=`; tolerance for spaces/quotes; name not present → undefined.
 
-**`src/token-gate.test.ts`** — fake req（headers）+ fake sessions（复用 MemTable 思路）+ fake resolver：
+**`src/token-gate.test.ts`** — fake req (headers) + fake sessions (reuse the MemTable approach) + fake resolver:
 
-1. 白名单：`/auth`、`/auth/login`、`/auth/whatever` → allow（无任何凭证）。
-2. cookie 通道：`sessions()` 返回有效会话 → allow；未知/过期/revoked → 继续走 bearer 或 deny。
-3. bearer 通道：`Authorization: Bearer <正确 token>` → allow；错误 token → deny；大小写 `bearer` 前缀可接受；`sessions: () => undefined` 时 cookie 通道跳过但 bearer 仍可用。
-4. 无任何凭证 → deny。
-5. fail-closed：resolver 抛错 → deny（不向上抛）。
-6. `safeEqual` 已知向量：`safeEqual("abc", "abc") === true`、`safeEqual("abc", "abd") === false`、空串对非空 → false。
+1. Whitelist: `/auth`, `/auth/login`, `/auth/whatever` → allow (with no credentials at all).
+2. cookie channel: `sessions()` returns a valid session → allow; unknown/expired/revoked → continue to bearer or deny.
+3. bearer channel: `Authorization: Bearer <correct token>` → allow; wrong token → deny; lowercase `bearer` prefix accepted; with `sessions: () => undefined` the cookie channel is skipped but bearer still works.
+4. No credentials at all → deny.
+5. fail-closed: resolver throws → deny (does not rethrow).
+6. `safeEqual` known vectors: `safeEqual("abc", "abc") === true`, `safeEqual("abc", "abd") === false`, empty string vs non-empty → false.
 
-**`src/form-body.test.ts`** — 正常解析（`token=x&next=%2F`）；无 content-type → 415；非 urlencoded → 415；
-`application/x-www-form-urlencoded; charset=UTF-8` → 正常（分号后参数忽略）；
-`application/x-www-form-urlencodedx` → 415（全等判定，M10）；超 16 KiB → 413 且**不调用
-`req.destroy()`**（fake req 记录 destroy 调用次数，M19）。
+**`src/form-body.test.ts`** — normal parse (`token=x&next=%2F`); no content-type → 415; non-urlencoded → 415;
+`application/x-www-form-urlencoded; charset=UTF-8` → normal (parameters after the semicolon ignored);
+`application/x-www-form-urlencodedx` → 415 (exact-equality check, M10); over 16 KiB → 413 and **does not call
+`req.destroy()`** (fake req records destroy call count, M19).
 
-**`src/auth-endpoints.test.ts`**（按文件行数上限拆为三个文件：`auth-endpoints.test.ts` 覆盖注册形状/
-GET login/logout/status，`auth-endpoints.login.test.ts` 覆盖 POST login，`auth-endpoints.methods.test.ts`
-覆盖 405/兜底/loginPageHtml——测试矩阵合并描述）— fake register（记录路由 + 返回 disposer）+ fake
-sessions（访问器形态）+ fake validateToken：
+**`src/auth-endpoints.test.ts`** (split into three files to honor the per-file line cap: `auth-endpoints.test.ts` covers registration shape/
+GET login/logout/status, `auth-endpoints.login.test.ts` covers POST login, `auth-endpoints.methods.test.ts`
+covers 405/fallback/loginPageHtml — test matrix described together) — fake register (records routes + returns disposers) + fake
+sessions (accessor form) + fake validateToken:
 
-1. 注册形状：4 条路由——prefix `/auth`、exact `/auth/login`、`/auth/logout`、`/auth/status`（M15）。
-2. GET login：200 + HTML 含 `<form`、hidden next 已 escape（`next="/x?a=1&b=2"` → HTML 里 `&amp;`）；已认证态（`sessions()` 有有效会话）也恒 200 渲染（不重定向，M20）。
-3. POST login 成功：validateToken true → 302 location=next + set-cookie 精确串（secure=true 与 false 两种）+ `sessions().create` 被调用（subject "token"、ttl = sessionTtl*1000）+ `logger.info("session issued")`。
-4. POST login 失败：validateToken false → 401 "invalid token" + `logger.info("login rejected")`；无会话创建。
-5. POST login next 校验：`next="//evil.com"` → 302 location "/"；`next="/ok/path"` → 302 "/ok/path"；**`next="/auth/login"` 与 `/auth/x` → "/"（M20）**。
-6. POST login `sessions()` undefined → 503 + `text/plain` + `logger.error`。
-7. POST logout：revoke 被调 + set-cookie 含 `Max-Age=0` + 302；next 从 query（`?next=/x` → location `/x`）；无 body/无 content-type 可用；cookie 缺失也 302（幂等，M22）。
-8. GET status：有效 cookie → `{"authenticated":true}`；无 → false；带 `Authorization: Bearer` 头不影响结果（只认 cookie，M5）。
-9. method 分发：`DELETE /auth/login` → 405 + `allow: GET, POST`；`GET /auth/logout` → 405；`POST /auth/status` → 405。
-10. prefix `/auth` 兜底：`/auth/whatever` → 404 + no-store（M20）。
-11. 413：body 超限 → 413 + `connection: close` 头 + 不调 `req.destroy`（M19）。
+1. Registration shape: 4 routes — prefix `/auth`, exact `/auth/login`, `/auth/logout`, `/auth/status` (M15).
+2. GET login: 200 + HTML contains `<form`, hidden next is escaped (`next="/x?a=1&b=2"` → `&amp;` in HTML); the authenticated state (`sessions()` has a valid session) also always 200 renders (no redirect, M20).
+3. POST login success: validateToken true → 302 location=next + exact set-cookie string (secure=true and false) + `sessions().create` called (subject "token", ttl = sessionTtl*1000) + `logger.info("session issued")`.
+4. POST login failure: validateToken false → 401 "invalid token" + `logger.info("login rejected")`; no session created.
+5. POST login next validation: `next="//evil.com"` → 302 location "/"; `next="/ok/path"` → 302 "/ok/path"; **`next="/auth/login"` and `/auth/x` → "/" (M20)**.
+6. POST login `sessions()` undefined → 503 + `text/plain` + `logger.error`.
+7. POST logout: revoke called + set-cookie contains `Max-Age=0` + 302; next from the query (`?next=/x` → location `/x`); no body/no content-type works; missing cookie still 302 (idempotent, M22).
+8. GET status: valid cookie → `{"authenticated":true}`; none → false; an `Authorization: Bearer` header does not affect the result (only honors cookie, M5).
+9. Method dispatch: `DELETE /auth/login` → 405 + `allow: GET, POST`; `GET /auth/logout` → 405; `POST /auth/status` → 405.
+10. prefix `/auth` fallback: `/auth/whatever` → 404 + no-store (M20).
+11. 413: body over limit → 413 + `connection: close` header + not calling `req.destroy` (M19).
 
-**`src/integration.auth.test.ts`**（真实入口路径）— 真实 cordis + **真实 storage 栈**
-（Storage → storage-json → storage-domain，挂载顺序同 M1 `integration.session.test.ts`；否则
-`sessions` 恒 undefined → 登录恒 503）+ 真实 WebServer + **结构型假
-credentials provider**（M18：`ctx.provide("credentials", { resolve: async (ref) => ref === "DSH_AUTH_TOKEN" ? { value: TEST_TOKEN, source: "test" } : undefined })`，
-**先于本插件挂载**；`TEST_TOKEN` 随机生成、永不进快照）+ 本插件（config `{ cookieSecure: false }`，http 无 TLS）：
+**`src/integration.auth.test.ts`** (real entry path) — real cordis + **real storage stack**
+(Storage → storage-json → storage-domain, mount order same as M1 `integration.session.test.ts`; otherwise
+`sessions` is always undefined → login always 503) + real WebServer + **structural fake
+credentials provider** (M18: `ctx.provide("credentials", { resolve: async (ref) => ref === "DSH_AUTH_TOKEN" ? { value: TEST_TOKEN, source: "test" } : undefined })`,
+**mounted before this plugin**; `TEST_TOKEN` randomly generated, never enters snapshots) + this plugin (config `{ cookieSecure: false }`, http no TLS):
 
-1. 全流程：`GET /auth/login` → 200；`POST /auth/login` 错 token → 401；对 token →
-   302 + `set-cookie` 头 + `location`；带 cookie `GET /__probe`（auth 之后注册的 exact 路由）→ 200；
-   无 cookie `GET /__probe` → 302（HTML accept）/ 401（JSON accept）；`Authorization: Bearer 对` → 200；
-   Bearer 错 → 401；`POST /auth/logout?next=/`（带 cookie，无 body）→ 302 + Max-Age=0；原 cookie 再访问 `/__probe` → 401。
-2. 白名单兜底：`GET /auth/whatever` → 404（非 SPA fallback）；`DELETE /auth/login` → 405。
-3. credentials 缺失（不挂 provider）→ 登录 401（resolver undefined）+ 启动日志 error。
-4. WS 通道：带会话 cookie 的 upgrade → 101（upgrade 事件）；`Authorization: Bearer <对>` 的 upgrade → 101；无凭证 upgrade → 401 拒握手（复用 M1 `requestUpgradeStatus` 模式，加 cookie/authorization 头变体）。
-5. 会话持久化已在 M1 `integration.session.test.ts` 覆盖（复用）。
+1. Full flow: `GET /auth/login` → 200; `POST /auth/login` wrong token → 401; correct token →
+   302 + `set-cookie` header + `location`; with cookie `GET /__probe` (an exact route registered after auth) → 200;
+   without cookie `GET /__probe` → 302 (HTML accept) / 401 (JSON accept); `Authorization: Bearer correct` → 200;
+   Bearer wrong → 401; `POST /auth/logout?next=/` (with cookie, no body) → 302 + Max-Age=0; the same cookie accessing `/__probe` again → 401.
+2. Whitelist fallback: `GET /auth/whatever` → 404 (not SPA fallback); `DELETE /auth/login` → 405.
+3. credentials missing (no provider mounted) → login 401 (resolver undefined) + startup log error.
+4. WS channel: upgrade with a session cookie → 101 (upgrade event); upgrade with `Authorization: Bearer <correct>` → 101; no credentials upgrade → 401 reject handshake (reuse M1 `requestUpgradeStatus` pattern, add cookie/authorization header variants).
+5. Session persistence already covered in M1 `integration.session.test.ts` (reused).
 
 ---
 
-## 6. 实施顺序（每步保持 `npm run verify` 绿）
+## 6. Implementation Order (keep `npm run verify` green at every step)
 
-1. `session-store.ts` buildSetCookie 加参 + `session-store.test.ts` 补用例：`secure=false` 精确串
-   `dsh_auth=tok; Max-Age=604800; Path=/; HttpOnly; SameSite=Lax`、缺省第 4 参 → 原精确串不变（向后兼容）。
-2. `src/cookie.ts` + 测试。
-3. `src/token-gate.ts` + 测试。
-4. `src/form-body.ts` + 测试。
-5. `src/login-page.ts`（纯渲染，随 auth-endpoints 测试覆盖；可先写后测）。
-6. `src/auth-endpoints.ts` + 测试。
-7. `src/index.ts` 装配 + `src/index.test.ts` 适配（mode=password 抛错、credentials 缺失 fail-closed、gate 为 TokenGate 实例）。
-8. `src/integration.auth.test.ts`。
-9. `docs/development.md` Structure 树更新为：
+1. `session-store.ts` — `buildSetCookie` gains the param + `session-store.test.ts` adds cases: `secure=false` exact string
+   `dsh_auth=tok; Max-Age=604800; Path=/; HttpOnly; SameSite=Lax`, default 4th param → the original exact string unchanged (backward compatible).
+2. `src/cookie.ts` + tests.
+3. `src/token-gate.ts` + tests.
+4. `src/form-body.ts` + tests.
+5. `src/login-page.ts` (pure rendering, covered by the auth-endpoints tests; may be written before tests).
+6. `src/auth-endpoints.ts` + tests.
+7. `src/index.ts` assembly + `src/index.test.ts` adaptation (mode=password throws, credentials missing fail-closed, gate is a TokenGate instance).
+8. `src/integration.auth.test.ts`.
+9. `docs/development.md` Structure tree updated to:
    ```
    src/
-   ├── index.ts           # plugin entry + auth 服务接线 + credentials 解析器（M2 改装配）
-   ├── guard.ts           # 守卫包装/拒绝管线 + AUTH_PATH_PREFIX（M2 加常量）
-   ├── gate.ts            # Gate 词表 + noopGate（M2 换真门）
-   ├── token-gate.ts      # TokenGate：白名单/cookie/Bearer + safeEqual（M2 新增）
-   ├── cookie.ts          # Cookie 头解析（M2 新增）
-   ├── form-body.ts       # urlencoded body 读取（M2 新增）
-   ├── login-page.ts      # 自包含登录页（M2 新增）
-   ├── auth-endpoints.ts  # /auth 兜底前缀 + 三个 exact 端点（M2 新增）
-   ├── session-store.ts   # storage-domain 会话持久化（buildSetCookie 加参）
-   ├── self-check.ts      # 包装覆盖自检（fail loud）
-   ├── *.test.ts          # 单元测试（显式 vitest import）
-   └── integration.*.test.ts  # 真实 cordis/webserver/storage 栈集成测试
+   ├── index.ts           # plugin entry + auth service wiring + credentials resolver (M2 changed assembly)
+   ├── guard.ts           # guard wrapping/reject pipeline + AUTH_PATH_PREFIX (M2 added constant)
+   ├── gate.ts            # Gate vocabulary + noopGate (M2 swapped real gate)
+   ├── token-gate.ts      # TokenGate: whitelist/cookie/Bearer + safeEqual (M2 added)
+   ├── cookie.ts          # Cookie header parsing (M2 added)
+   ├── form-body.ts       # urlencoded body reading (M2 added)
+   ├── login-page.ts      # self-contained login page (M2 added)
+   ├── auth-endpoints.ts  # /auth fallback prefix + three exact endpoints (M2 added)
+   ├── session-store.ts   # storage-domain session persistence (buildSetCookie param added)
+   ├── self-check.ts      # wrapped-coverage self-check (fail loud)
+   ├── *.test.ts          # unit tests (explicit vitest imports)
+   └── integration.*.test.ts  # real cordis/webserver/storage stack integration tests
    ```
-   `docs/handoff-m2.md` 状态快照（§2）与 §5.4 冒烟序列同步更新。
+   `docs/handoff-m2.md` status snapshot (§2) and §5.4 smoke sequence updated in sync.
 
 ---
 
 ## 7. Definition of Done
 
-1. `npm run verify` 全绿（format/lint/type-check/coverage ≥80%/lock:check）。
-2. `npm run build` + `lib/` 与 `src/` 同批；`git diff --exit-code -- lib` 通过。
-3. `npm run test -- src/integration.auth.test.ts src/integration.guard.test.ts src/integration.session.test.ts` 单独跑绿。
-4. **服务器端到端冒烟**（交接文档 §5 工作流，真实 LocalCredentialProvider）：overlay 加
-   `config: { cookieSecure: false }` + `$DSH_HOME/.credentials.yaml` 写 `DSH_AUTH_TOKEN: <测试值>`
-   （`chmod 600`）→ 重启实例 → curl 验证：未认证 `/__auth_probe` → 302/401；POST 登录 → Set-Cookie；
-   带 cookie → 200；Bearer → 200；`GET /auth/whatever` → 404（兜底）；WS upgrade 带 cookie → 101 /
-   无凭证 → 401。
-5. 报告：改动文件、M1–M22 落点、覆盖率数字、与本文档的偏差（应为零）。
+1. `npm run verify` all green (format/lint/type-check/coverage ≥80%/lock:check).
+2. `npm run build` + `lib/` in the same change as `src/`; `git diff --exit-code -- lib` passes.
+3. `npm run test -- src/integration.auth.test.ts src/integration.guard.test.ts src/integration.session.test.ts` runs green standalone.
+4. **Server end-to-end smoke** (handoff doc §5 workflow, real LocalCredentialProvider): overlay adds
+   `config: { cookieSecure: false }` + `$DSH_HOME/.credentials.yaml` writes `DSH_AUTH_TOKEN: <test value>`
+   (`chmod 600`) → restart instance → curl verification: unauthenticated `/__auth_probe` → 302/401; POST login → Set-Cookie;
+   with cookie → 200; Bearer → 200; `GET /auth/whatever` → 404 (fallback); WS upgrade with cookie → 101 /
+   no credentials → 401.
+5. Report: changed files, M1–M22 landing points, coverage numbers, deviation from this document (should be zero).
 
 ---
 
-## 8. 禁区清单
+## 8. Forbidden List
 
-- **不探索 harness 内部**（同 M1）；credentials 服务只经 §3.1 的结构类型。
-- **零新增依赖**（M18）：runtime 与 devDependencies 都不动——`node:crypto`/`URLSearchParams` 够用；
-  body 解析/HTML 渲染/cookie 解析全部手写；集成测试用结构型假 credentials provider，**不引入**
-  `dsh-credentials-local`。
-- **不把凭证落日志/快照**：token 值、session token 永不进日志/测试快照；`resolveToken` 失败只记错误消息。
-- **不吞认证失败**：登录失败必须 401（不是静默放行）；credentials 缺失必须 deny（fail-closed）。
-- **不动 M1 守卫行为**：`guard.ts` 仅新增 `AUTH_PATH_PREFIX` 常量（行为不变）；`gate.ts`/`self-check.ts`
-  不动（`noopGate` 保留导出）。
-- **不改门禁/tsconfig/eslint/vitest 配置**；不改依赖之外的 package.json。
-- **分支纪律**：`development`；未获指令不 commit/push。
-- M3/M4（users.yaml、argon2id、限速、TOTP、`dsh-auth user` CLI）**不做**——需要时只写 `TODO(auth-m3):` 注释。
+- **Do not explore harness internals** (same as M1); the credentials service is only accessed via §3.1's structural type.
+- **Zero new dependencies** (M18): neither runtime nor devDependencies change — `node:crypto`/`URLSearchParams` suffice;
+  body parsing/HTML rendering/cookie parsing are all handwritten; integration tests use a structural fake credentials provider, **do not introduce**
+  `dsh-credentials-local`.
+- **Do not put credentials into logs/snapshots**: token values, session tokens never enter logs/test snapshots; `resolveToken` failure logs only the error message.
+- **Do not swallow auth failures**: login failure must be 401 (not silent allow); credentials missing must deny (fail-closed).
+- **Do not touch M1 guard behavior**: `guard.ts` only adds the `AUTH_PATH_PREFIX` constant (behavior unchanged); `gate.ts`/`self-check.ts`
+  unchanged (`noopGate` keeps its export).
+- **Do not change gates/tsconfig/eslint/vitest config**; no package.json changes beyond dependencies.
+- **Branch discipline**: `development`; no commit/push without instruction.
+- M3/M4 (users.yaml, argon2id, rate limiting, TOTP, `dsh-auth user` CLI) **not done** — when needed, only write `TODO(auth-m3):` comments.
 
 ---
 
-## 9. 明确不做（M2 范围外）
+## 9. Explicitly Not Done (Out of M2 Scope)
 
-- users.yaml / 多凭证 / 口令登录 / argon2id / 登录限速（M3）。
-- TOTP 两段式登录（M4）。
-- 登录页美化 / 国际化 / client 半边登出按钮（GUI 组件）。
-- CSRF token（M14 注明，M3 评估）。
-- 部署侧交付物（正式 `cordis.patch.yml` 生产 patch、部署验收清单）——M2 代码验证后单独做。
+- users.yaml / multiple credentials / password login / argon2id / login rate limiting (M3).
+- TOTP two-step login (M4).
+- Login page beautification / internationalization / client-side logout button (GUI components).
+- CSRF token (noted in M14, M3 evaluates).
+- Deployment-side deliverables (official `cordis.patch.yml` production patch, deployment acceptance checklist) — done separately after M2 code verification.

--- a/docs/impl-m2_zh.md
+++ b/docs/impl-m2_zh.md
@@ -1,0 +1,470 @@
+# dsh-auth M2 实施规格（executable spec）
+
+> 读者：执行实现的编码代理（预期 deepseek v4 flash，**新 session**）。本文档是**决策完备的规格**：
+> 所有判断点已预先关闭，执行者只做翻译，不做设计。
+> 基线：`docs/impl-m1_zh.md`（M1 已交付：守卫包装、自检、会话存储、auth 服务骨架——M2 在其上叠加）。
+> 设计依据：`docs/dsh-auth-plan_zh.md` §5/§6 阶段 1/§8；工程门禁：`docs/development.md`。
+> **本文件是 M2 的唯一权威细则**；与 plan/M1 冲突时以本文件为准。
+>
+> 环境与验证工作流见 `docs/handoff-m2_zh.md`（新 session 必读：服务器访问、沙箱网络限制、
+> M1 踩坑清单）。**禁止自行探索 harness 内部**——需要本文件之外的事实，停下报告。
+
+---
+
+## 1. M2 目标
+
+把 M1 的惰性门（`noopGate` 全放行）替换为**共享 token 门**：
+
+- 未认证请求被守卫拒绝（HTML 导航 → 302 登录页；API/WS → 401/拒握手——M1 管线已就绪）；
+- `GET /auth/login` 自包含登录页 + `POST /auth/login` 提交 token → 恒时校验 → 发持久化会话 cookie；
+- `Authorization: Bearer <token>` 直接通过守卫（curl/脚本友好）；
+- `POST /auth/logout` 吊销会话；`GET /auth/status` 报告认证状态；其余 `/auth/*` 路径一律 404 兜底
+  （不落到 SPA fallback）。
+
+M1 的守卫/会话/自检全部复用，**不改其行为**；本里程碑只换门 + 加端点。
+
+---
+
+## 2. 冻结决策表（M2 增量；M1 的 D1–D16 不变）
+
+| #   | 决策         | 冻结值                                                                                                                                                                                                                                                                                                                                       |
+| --- | ------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| M1  | gate 替换    | `apply` 用 `TokenGate` 实例替换 `noopGate`；`AuthService.gate` 字段保持可写（测试注入、M3 换门兼容）                                                                                                                                                                                                                                         |
+| M2  | token 来源   | config `tokenRef: string` = credentials 引用名（环境变量名），默认 `"DSH_AUTH_TOKEN"`；**每次 decide 经 `ctx.credentials.resolve(tokenRef)` 重新解析**（credentials 服务 per-operation 语义，改凭证无需重启）；credentials 服务缺失 → **首次解析时** `log.error` + 门**恒 deny**（fail-closed；告警惰性触发——见 §3.1 挂载竞态）              |
+| M3  | 校验方式     | 恒时比较：`crypto.timingSafeEqual(sha256(input), sha256(stored))`（双方先哈希再比较，长度恒等；`safeEqual(input, stored)` 导出可测）                                                                                                                                                                                                         |
+| M4  | 公共路径     | `TokenGate` 恒放行 `/auth` 与 `/auth/*`（常量 `AUTH_PATH_PREFIX = "/auth"` 放 `guard.ts`）；兜底前缀 + 三个 exact 端点经**包装后的** `register` 注册（被守卫包装但被 gate 放行——与 plan §5 白名单一致，自检无缺口、重启自愈；不做独立白名单配置项）                                                                                          |
+| M5  | 端点集       | `GET /auth/login`（自包含 HTML）、`POST /auth/login`（urlencoded：`token` + `next`）、`POST /auth/logout`、`GET /auth/status`（JSON `{ authenticated: boolean }`）。路由模型见 M15（3 exact + 1 prefix 兜底）；`/auth/status` **只认 cookie**（Bearer 不参与——无状态通道不建会话，不是"会话状态"）                                           |
+| M6  | 会话语义     | 登录成功 → `SessionStore.create("token", ttl)`（subject 恒 `"token"`，plan §5；**每次登录都是新会话**，防固定天然满足）；cookie 由 `buildSetCookie` 输出                                                                                                                                                                                     |
+| M7  | cookieSecure | config `cookieSecure: boolean` 默认 `true`；`false` 时 cookie 省略 `; Secure`（http 测试/开发）。`buildSetCookie` 增加可选第 4 参 `secure = true`（**向后兼容** M1 签名与测试）                                                                                                                                                              |
+| M8  | next 校验    | 必须以单个 `/` 开头、非 `//` 开头、不含 `\`；否则回落 `/`（防开放重定向）                                                                                                                                                                                                                                                                    |
+| M9  | Bearer       | `Authorization: Bearer <token>` 恒时校验通过即放行，**不建会话**；HTTP 与 upgrade 都生效（浏览器 WS 无法自定义头，cookie 是浏览器通道——文档注明）                                                                                                                                                                                            |
+| M10 | body 解析    | 仅接受 `application/x-www-form-urlencoded`（判定：取首个 `;` 前的 token，`trim().toLowerCase()` 后**全等**——不用 startsWith，会误收 `...x` 后缀）；大小上限 16 KiB（超限 413，见 M19）；`URLSearchParams` 解析；不符 415                                                                                                                     |
+| M11 | mode 语义    | `"token"`（默认）激活 TokenGate；`"password"` 在 M2 `apply` 直接抛错（fail loud；M3 实现）                                                                                                                                                                                                                                                   |
+| M12 | 依赖         | **零新增**：`node:crypto`/`URLSearchParams` 内建；credentials 服务用结构类型 `ctx.get("credentials") as unknown as CredentialRefResolver`（不 import 包类型 → 不加依赖）                                                                                                                                                                     |
+| M13 | 限速         | M2 **不做**（token 256-bit 熵足够；M3 password 流加 IP+账号限速）                                                                                                                                                                                                                                                                            |
+| M14 | CSRF         | M2 不做登录/登出 CSRF token（登录 CSRF 影响可忽略、`SameSite=Lax` 已覆盖大部分；文档注明，M3 评估）                                                                                                                                                                                                                                          |
+| M15 | 路由模型     | webserver **无 method 路由**（`exact` 表只按 pathname 建键、重复 path 抛错——实测）→ **3 条 exact 路由**（`/auth/login`、`/auth/logout`、`/auth/status`）+ **1 条 prefix 兜底**（`/auth` → 404，防未注册 `/auth/*` 落到 SPA fallback，M20）；每个 exact handler 内部按 `req.method` 分发，非白名单 method → `405` + `allow` 头 + `text/plain` |
+| M16 | 会话访问器   | `sessions` 一律以访问器 `() => SessionStore \| undefined` 注入（TokenGate 与 AuthEndpointsDeps **同形**）；`apply` 中 `auth` 对象**一步成型**：`gate: new TokenGate({ ..., sessions: () => auth.sessions })`（闭包自引用，apply 内无 await、无裸奔窗口）；`noopGate` import 移除（`gate.ts` 导出保留，测试用）                               |
+| M17 | 恒时比较     | `timingSafeEqual` **只接受 Buffer/TypedArray**（hex 字符串直接 TypeError——本机实测）→ `safeEqual` 用 `createHash("sha256").update(x).digest()`（Buffer，双方恒 32 字节），**不用** `digest("hex")`                                                                                                                                           |
+| M18 | 测试凭证     | 集成测试用**结构型假 provider**（`ctx.provide("credentials", { resolve })`，先于本插件挂载）；真实 `LocalCredentialProvider` 只在服务器冒烟（DoD 4）覆盖。**零新增依赖（含 devDependencies）**——`dsh-credentials-local` 及其 5 个 peer 包不进 package.json                                                                                   |
+| M19 | 413 处理     | 超限：停止累积、`throw { status: 413 }`；端点写 `connection: close` + `413` + `res.end()`，**不调用 `req.destroy()`**（实测：destroy 会毁掉 keep-alive，后续请求 socket hang up）                                                                                                                                                            |
+| M20 | 白名单兜底   | prefix `/auth` 兜底路由经**包装后**的 register 注册，handler 恒 404（自检计入覆盖）；`validateNext` 额外拒绝 `"/auth"` 与 `/auth/*`（回落 `/`）——防登录后 302 回环；`GET /auth/login` 恒渲染登录页（不查会话、不重定向）                                                                                                                     |
+| M21 | 端点日志     | 冻结日志事件：登录失败 `info`（"login rejected"）、登录成功 `info`（"session issued"）、503 `error`、logout `info`（"logout"）；**任何日志永不包含 token 值/session token**（`AuthEndpointsDeps.logger` 由此消费）                                                                                                                           |
+| M22 | logout 语义  | `next` 仅从 **query** 取（无则 `/`）；**不解析 body、不要求 content-type**（裸 `curl -X POST` 可用）；cookie 缺失也照常 302 + 清 cookie（幂等）                                                                                                                                                                                              |
+
+---
+
+## 3. 权威契约（M2 新增；其余见 impl-m1.md §2）
+
+### 3.1 credentials 服务（`@deepseek-ai/dsh-credentials@0.1.0-rc.6` + `dsh-credentials-local`）
+
+- **web 组合自带**：`dsh-base` bundle 的 `credentials` 行 = `@deepseek-ai/dsh-credentials-local`（读
+  `$DSH_HOME/.credentials.yaml`，env 层优先于文件层；**每次 resolve 重新读取**，改文件无需重启）。
+- **挂载竞态（实测）**：harness **并行挂载行**——credentials 行（dsh-base）可能在本插件（用户层）
+  apply **之后**才就绪（服务器冒烟实测：apply 时 `ctx.get("credentials") === undefined`，数秒后
+  可见）。因此解析器**每次 resolve 惰性 `ctx.get("credentials")`**（§4.6 item 3），缺失告警也在
+  首次解析时触发——既是 M2 的 per-operation 语义，也天然规避竞态（M2 行冻结值已同步修订）。
+- 服务面：`ctx.credentials.resolve(ref): Promise<{ value: string; source: string } | undefined>`
+  （ref 是环境变量名形式的字符串；未配置 → `undefined`）。我们**不 import 包类型**，用结构类型：
+  ```ts
+  interface CredentialRefResolver {
+    resolve(ref: string): Promise<{ value: string; source: string } | undefined>;
+  }
+  ```
+- 本插件**只读**凭证，不 set/unset。`CredentialRefResolver` 结构接口声明在 `src/index.ts`
+  （私有，不导出）。
+- `dsh-credentials-local` 是类插件（named export `LocalCredentialProvider`，Config 含 `path?`）：
+  服务器冒烟直接复用 web 组合自带的 `credentials` 行，写 `$DSH_HOME/.credentials.yaml`。
+  **文件权限必须 0600**：`assertOwnerOnly` 在文件存在且 group/other 可读时启动即抛错
+  （`chmod 600`）。**集成测试不挂真实 provider**（M18：零新增依赖）——用结构型假 provider
+  `ctx.provide("credentials", { resolve })` 先于本插件挂载；真实 provider 的 env 层优先语义
+  （`process.env[tokenRef]` 可直接供冒烟）在服务器侧验证。
+- 服务缺失（首次解析时 `ctx.get("credentials") === undefined`，惰性）：`log.error("credentials
+service is unavailable: gate denies everything (fail-closed)")` 一次；`TokenGate` 的 resolver
+  返回 `undefined` → 所有凭证校验失败 → 恒 deny（但白名单 `/auth/*` 仍放行，登录页可见、登录
+  不可用——可诊断）。
+
+### 3.2 node 内建（本包静态形态，均可用）
+
+- `node:crypto`：`randomBytes`（M1 已用）、`createHash("sha256")`、`timingSafeEqual`。
+- `URLSearchParams`（global，Node ≥ 22）：解析 urlencoded body 与构造 query。
+- `req` 流读取：`for await (const chunk of req)` 累积，超限即断（413，M19）。
+- `timingSafeEqual(a, b)` 只接受 Buffer/TypedArray/DataView——hex 字符串直接抛 TypeError（本机
+  实测）；`safeEqual` 内部一律 `digest()`（Buffer，M17），不用 `digest("hex")`。
+
+---
+
+## 4. 文件蓝图
+
+每个文件 ≤250 行、函数 ≤80 行、复杂度 ≤15（ESLint error）。M1 文件只增改三处：`session-store.ts`
+（`buildSetCookie` 加参）、`guard.ts`（仅新增 `AUTH_PATH_PREFIX` 常量，行为不变）、`src/index.ts`
+（装配）。**gate/self-check 不动**（`gate.ts` 的 `noopGate` 保留导出——测试仍用；`GuardKind`/`Gate` 不变）。
+
+### 4.1 `src/cookie.ts` —— 请求 Cookie 头解析
+
+```ts
+/** 从 Cookie 头解析指定名字的值；同名取首个。无头/无此名 → undefined。 */
+export function parseCookieHeader(header: string | undefined, name: string): string | undefined;
+```
+
+行为约定：`split(";")` → 每段 `trim()` → 首个 `"="` 切分 → 名字精确匹配。值不去引号（token 无引号）。
+空值返回 `""`（调用方自行判定）。纯函数，导出测试。
+
+### 4.2 `src/token-gate.ts` —— 共享 token 门
+
+```ts
+import type { IncomingMessage } from "node:http";
+import { createHash, timingSafeEqual } from "node:crypto";
+import type { Gate, GuardKind } from "./gate.js";
+import type { SessionStore } from "./session-store.js";
+import { AUTH_PATH_PREFIX } from "./guard.js";
+import { parseCookieHeader } from "./cookie.js";
+
+/**
+ * 恒时比较：双方 sha256 Buffer 摘要后 timingSafeEqual（M17：timingSafeEqual 只接受
+ * Buffer/TypedArray——hex 字符串直接 TypeError；Buffer 摘要双方恒 32 字节，无长度侧信道）。
+ */
+export function safeEqual(input: string, stored: string): boolean;
+
+export interface TokenGateOptions {
+  /** 每次 decide 调用的凭证解析器（index.ts 注入 credentials.resolve 闭包）。 */
+  resolveToken: () => Promise<string | undefined>;
+  /** 会话访问器（M16）：每次 decide 现取——domain 异步就绪；undefined = cookie 通道不可用。 */
+  sessions: () => SessionStore | undefined;
+  cookieName: string;
+}
+
+export class TokenGate implements Gate {
+  constructor(options: TokenGateOptions);
+  decide(req: IncomingMessage, kind: GuardKind, pathname: string): Promise<"allow" | "deny">;
+}
+```
+
+`decide` 顺序（照此实现）：
+
+1. `pathname === AUTH_PATH_PREFIX || pathname.startsWith(AUTH_PATH_PREFIX + "/")` → `"allow"`。
+2. cookie：`parseCookieHeader(req.headers.cookie, this.cookieName)` → 非空
+   （`!== undefined && !== ""`）且 `this.sessions()?.getByToken(token) !== undefined` → `"allow"`
+   （`sessions()` 返回 undefined 则跳过此通道）。
+3. Bearer：`req.headers.authorization` 匹配 `/^Bearer\s+(.+)$/i` → `await this.resolveToken()` →
+   存在且 `safeEqual(bearer, stored)` → `"allow"`。
+4. 否则 `"deny"`。
+
+错误语义（fail-closed）：`resolveToken` 抛错 → 本门 catch 后返回 `"deny"`（不向上抛、不打日志；
+index.ts 的 resolver 已自行 catch 并记日志——生产路径不会抛到此处，本 catch 是防御性双保险）。
+
+### 4.3 `src/form-body.ts` —— urlencoded 表单体读取
+
+```ts
+import type { IncomingMessage } from "node:http";
+
+export const FORM_BODY_LIMIT = 16 * 1024;
+
+/** 读取并解析 urlencoded 请求体。返回 415（content-type 不符）/ 413（超限）时抛出带 status 的错误。 */
+export async function parseFormBody(req: IncomingMessage): Promise<URLSearchParams>;
+```
+
+行为约定：`content-type` 判定取首个 `;` 前的 token，`trim().toLowerCase()` 后**全等**
+`application/x-www-form-urlencoded`（M10：不用 startsWith，会误收 `...x` 后缀），不符
+`throw Object.assign(new Error("unsupported media type"), { status: 415 })`；
+`for await` 累积 chunks，总量 > `FORM_BODY_LIMIT` 时停止累积并
+`throw ... { status: 413 }`（**不调用 `req.destroy()`**，M19）；`new URLSearchParams(decoded)` 解析。
+错误对象带 `status` 字段——auth-endpoints 据此写响应；**不带 `status` 的流异常（abort 等）不捕获，
+向上抛**（webserver 统一 warn + 400，与守卫纪律一致）。
+
+### 4.4 `src/login-page.ts` —— 自包含登录页
+
+```ts
+/** 渲染自包含登录页（内联样式，零第三方资源）。next/error 全部 HTML-escape。 */
+export function loginPageHtml(next: string, error?: string): string;
+```
+
+行为约定：`<!doctype html>` + `lang="en"`；内联 `<style>`（基础居中卡片样式，light 即可，不引外部字体）；
+`<form method="post" action="/auth/login">`；hidden `next`（escape 后）；`<input type="password" name="token"
+autocomplete="current-password" required autofocus>`；`<button type="submit">Unlock</button>`；
+`error` 非空时渲染 `<p class="error">`（escape）。HTML-escape helper 为本文件私有
+（`& < > " '` 五个字符），导出仅 `loginPageHtml`。
+
+### 4.5 `src/auth-endpoints.ts` —— /auth 兜底 + 三个端点
+
+```ts
+import { AUTH_PATH_PREFIX, type HttpHandler } from "./guard.js";
+import { buildSetCookie, type SessionStore } from "./session-store.js";
+import { parseFormBody } from "./form-body.js";
+import { loginPageHtml } from "./login-page.js";
+import { parseCookieHeader } from "./cookie.js";
+
+export interface AuthEndpointsDeps {
+  /** 注册路由（index.ts 传入包装后的 server.register；被守卫包装但被 gate 白名单放行）。 */
+  register(route: { kind: "exact" | "prefix"; path: string; handler: HttpHandler }): () => void;
+  /** 会话访问器（M16）：domain 异步就绪，端点内每次现取。 */
+  sessions: () => SessionStore | undefined;
+  cookieName: string;
+  cookieSecure: boolean;
+  sessionTtl: number; // 秒
+  validateToken: (token: string) => Promise<boolean>; // 恒时校验（index.ts 注入 safeEqual 闭包）
+  logger: { error(message: unknown): void; info(message: unknown): void };
+}
+
+/** 注册 prefix `/auth` 兜底 + 三个 exact 端点；返回合并 disposer（内部收集每个 register 的 disposer）。 */
+export function registerAuthEndpoints(deps: AuthEndpointsDeps): () => void;
+```
+
+路由模型（M15：webserver 无 method 路由——`exact` 表只按 pathname 建键、重复 path 抛错，故
+GET/POST `/auth/login` **不能**注册两条 exact 路由）：
+
+- **prefix `AUTH_PATH_PREFIX`（= `"/auth"`，兜底，M20）**：恒 `404` + `content-type: text/plain` +
+  no-store——未注册的 `/auth/*` 不得落到 SPA fallback（exact 优先于 prefix，不遮蔽下面三个端点）。
+  路由 path 用 `AUTH_PATH_PREFIX` 常量（本节 import 的唯一消费方）。
+- **exact `/auth/login`**：handler 内按 `req.method` 分发：
+  - `GET`：`next = validateNext(query.get("next") ?? "/")` → `200` +
+    `content-type: text/html; charset=utf-8` + `cache-control: no-store` + `loginPageHtml(next)`。
+    **恒渲染登录页**（不查会话、不重定向——M20）。
+  - `POST`：`parseFormBody(req)`——带 `status` 的错误 → 对应 status + `text/plain` 消息
+    （413 额外先 `res.setHeader("connection", "close")`，M19）；**不带 `status` 的异常向上抛**
+    （webserver 统一 warn + 400）；`token = params.get("token") ?? ""`；
+    `next = validateNext(params.get("next") ?? "/")`；
+    `await deps.validateToken(token)` 失败 → `401` + `text/plain` `"invalid token"` +
+    `cache-control: no-store` + `logger.info("login rejected")`；
+    成功 → `const store = deps.sessions(); store === undefined` → `503` + `text/plain`
+    `"session store unavailable"` + no-store + `logger.error("login failed: session store unavailable")`
+    （fail-closed，不静默放行）；否则
+    `const { token: sessionToken } = await store.create("token", deps.sessionTtl * 1000)`；
+    `res.setHeader("set-cookie", buildSetCookie(deps.cookieName, sessionToken, deps.sessionTtl, deps.cookieSecure))`；
+    `res.writeHead(302, { location: next }); res.end();` + `logger.info("session issued")`
+    （全程 no-store）。
+  - 其他 method → `405` + `allow: GET, POST` + `text/plain`（no-store）。
+- **exact `/auth/logout`**：仅 `POST`（其他 → `405` + `allow: POST`）：
+  `next = validateNext(query.get("next") ?? "/")`（M22：next 仅从 query 取；
+  **不解析 body、不要求 content-type**——裸 `curl -X POST` 可用）；
+  `const store = deps.sessions(); const token = parseCookieHeader(req.headers.cookie, deps.cookieName);`
+  `token` 非空（`!== undefined && !== ""`）且 `store !== undefined` →
+  `await store.revokeByToken(token)`（无会话/无 cookie 静默成功）；
+  `res.setHeader("set-cookie", buildSetCookie(deps.cookieName, "", 0, deps.cookieSecure))`（Max-Age=0 清除）；
+  `res.writeHead(302, { location: next }); res.end();` + `logger.info("logout")`；no-store。
+- **exact `/auth/status`**：仅 `GET`（其他 → `405` + `allow: GET`）：
+  只认 cookie（M5：Bearer 不参与——无状态通道不建会话，不是"会话状态"）：
+  `const store = deps.sessions(); const token = parseCookieHeader(req.headers.cookie, deps.cookieName);`
+  `const authenticated = store !== undefined && token !== undefined && token !== "" &&
+store.getByToken(token) !== undefined;`
+  → `200` + `application/json` + `JSON.stringify({ authenticated })` + no-store。
+
+`validateNext` 为本文件私有导出：`next` 以单个 `/` 开头
+（`next.startsWith("/") && !next.startsWith("//") && !next.includes("\\")`）**且**
+`next !== "/auth"`、`!next.startsWith("/auth/")`（M20：拒 /auth* 防登录后 302 回环）→ 原样；否则 `"/"`。
+`req.url` 的 query 解析用 `new URL(req.url ?? "/", "http://x")`（与守卫一致）。
+全部端点响应带 `cache-control: no-store`；日志事件见 M21（任何日志**永不**包含 token 值/session token）。
+
+### 4.6 `src/index.ts` —— 装配变更（其余 M1 逻辑不动）
+
+1. `Config` 增加两字段（默认值进 schemastery）：
+   ```ts
+   tokenRef: z.string().pattern(/^[A-Za-z_][A-Za-z0-9_]*$/).default("DSH_AUTH_TOKEN"),
+   cookieSecure: z.boolean().default(true),
+   ```
+   （`pattern` 与 dsh-credentials 的 credential-ref 模式一致，同时挡住空串。）
+   `AuthConfig` 接口同步（`mode`/`sessionTtl`/`cookieName` 不变）。
+2. `apply` 开头：`if (config.mode === "password") throw new Error("dsh-auth: password flow requires M3 (not implemented in M2)");`（在 `void config` 处改为真正使用 config）。
+3. credentials 解析器（替换 M1 的 `void config`）——**惰性取服务**（§3.1 挂载竞态：credentials 行
+   可能在本行 apply 之后才就绪，每次 resolve 现取 `ctx.get("credentials")`）：
+   ```ts
+   /** credentials 服务的结构镜像（§3.1）；本文件私有，不导出。 */
+   interface CredentialRefResolver {
+     resolve(ref: string): Promise<{ value: string; source: string } | undefined>;
+   }
+   /** 返回 resolveToken；服务缺失告警只在首次解析时触发一次（fail-closed，可诊断）。 */
+   function makeTokenResolver(
+     ctx: Context,
+     config: AuthConfig,
+     log: { error(message: unknown): void },
+   ): () => Promise<string | undefined> {
+     let warnedMissing = false;
+     return async () => {
+       const credentials = ctx.get("credentials") as unknown as CredentialRefResolver | undefined;
+       if (credentials === undefined) {
+         if (!warnedMissing) {
+           warnedMissing = true;
+           log.error("credentials service is unavailable: gate denies everything (fail-closed)");
+         }
+         return undefined;
+       }
+       try {
+         const resolved = await credentials.resolve(config.tokenRef);
+         return resolved?.value;
+       } catch (error) {
+         log.error(
+           `token resolution failed: ${error instanceof Error ? error.message : String(error)}`,
+         );
+         return undefined; // fail-closed：解析失败 = 无凭证
+       }
+     };
+   }
+   ```
+4. 装配门（M16）：替换 M1 第 3 步的 `{ sessions: undefined, gate: noopGate }`，`auth` 对象**一步成型**：
+   ```ts
+   const auth: AuthService = {
+     sessions: undefined,
+     gate: new TokenGate({
+       resolveToken,
+       sessions: () => auth.sessions, // 访问器闭包自引用 auth（domain 异步就绪后由 open 回调赋值）
+       cookieName: config.cookieName,
+     }),
+   };
+   ctx.provide("auth", auth);
+   ```
+   顺序：log → credentials/resolveToken → auth → provide；apply 内无 await、无裸奔窗口。闭包自引用
+   合法（`decide` 时才求值）。`noopGate` 的 import 移除（`gate.ts` 导出保留，测试用）。
+5. 端点注册（在 wrapServer 与自检之间；`safeEqual` 从 `./token-gate.js` import）：
+   ```ts
+   ctx.effect(
+     () =>
+       registerAuthEndpoints({
+         register: (route) => server.register(route), // 包装后的 register（增量保险路径）
+         sessions: () => auth.sessions,
+         cookieName: config.cookieName,
+         cookieSecure: config.cookieSecure,
+         sessionTtl: config.sessionTtl,
+         validateToken: async (token) => {
+           const stored = await resolveToken();
+           return stored !== undefined && safeEqual(token, stored);
+         },
+         logger: log,
+       }),
+     "dsh-auth: auth endpoints",
+   );
+   ```
+   自检在端点注册**之后**执行（端点也计入覆盖）。
+6. 移除对 `noopGate` 的 import（gate.ts 导出保留，测试用）。
+
+### 4.7 `src/session-store.ts` —— 一处向后兼容修改
+
+`buildSetCookie` 增加第 4 参：`secure: boolean = true`；`false` 时输出省略 `; Secure`：
+`${cookieName}=${token}; Max-Age=${maxAgeSeconds}; Path=/; HttpOnly; ${secure ? "Secure; " : ""}SameSite=Lax`
+（注意空格：`Path=/; HttpOnly; Secure; SameSite=Lax` 与 `Path=/; HttpOnly; SameSite=Lax` 都要精确）。
+
+---
+
+## 5. 测试矩阵
+
+M1 测试**全保留**；`src/index.test.ts` 按 §4.6 适配（gate 是 TokenGate 实例、mode=password 抛错、
+credentials 缺失 → resolver 恒 undefined + error 日志、storageDomain 与 credentials 双缺失 → 2 条
+error 日志、Config 默认值补 `tokenRef`/`cookieSecure`、fake ctx 增加 `credentials` 分支）。新增：
+
+**`src/cookie.test.ts`** — 无头 → undefined；单 cookie；多 cookie 取同名首个；值含 `=`；带空格/引号容错；名不存在 → undefined。
+
+**`src/token-gate.test.ts`** — fake req（headers）+ fake sessions（复用 MemTable 思路）+ fake resolver：
+
+1. 白名单：`/auth`、`/auth/login`、`/auth/whatever` → allow（无任何凭证）。
+2. cookie 通道：`sessions()` 返回有效会话 → allow；未知/过期/revoked → 继续走 bearer 或 deny。
+3. bearer 通道：`Authorization: Bearer <正确 token>` → allow；错误 token → deny；大小写 `bearer` 前缀可接受；`sessions: () => undefined` 时 cookie 通道跳过但 bearer 仍可用。
+4. 无任何凭证 → deny。
+5. fail-closed：resolver 抛错 → deny（不向上抛）。
+6. `safeEqual` 已知向量：`safeEqual("abc", "abc") === true`、`safeEqual("abc", "abd") === false`、空串对非空 → false。
+
+**`src/form-body.test.ts`** — 正常解析（`token=x&next=%2F`）；无 content-type → 415；非 urlencoded → 415；
+`application/x-www-form-urlencoded; charset=UTF-8` → 正常（分号后参数忽略）；
+`application/x-www-form-urlencodedx` → 415（全等判定，M10）；超 16 KiB → 413 且**不调用
+`req.destroy()`**（fake req 记录 destroy 调用次数，M19）。
+
+**`src/auth-endpoints.test.ts`**（按文件行数上限拆为三个文件：`auth-endpoints.test.ts` 覆盖注册形状/
+GET login/logout/status，`auth-endpoints.login.test.ts` 覆盖 POST login，`auth-endpoints.methods.test.ts`
+覆盖 405/兜底/loginPageHtml——测试矩阵合并描述）— fake register（记录路由 + 返回 disposer）+ fake
+sessions（访问器形态）+ fake validateToken：
+
+1. 注册形状：4 条路由——prefix `/auth`、exact `/auth/login`、`/auth/logout`、`/auth/status`（M15）。
+2. GET login：200 + HTML 含 `<form`、hidden next 已 escape（`next="/x?a=1&b=2"` → HTML 里 `&amp;`）；已认证态（`sessions()` 有有效会话）也恒 200 渲染（不重定向，M20）。
+3. POST login 成功：validateToken true → 302 location=next + set-cookie 精确串（secure=true 与 false 两种）+ `sessions().create` 被调用（subject "token"、ttl = sessionTtl*1000）+ `logger.info("session issued")`。
+4. POST login 失败：validateToken false → 401 "invalid token" + `logger.info("login rejected")`；无会话创建。
+5. POST login next 校验：`next="//evil.com"` → 302 location "/"；`next="/ok/path"` → 302 "/ok/path"；**`next="/auth/login"` 与 `/auth/x` → "/"（M20）**。
+6. POST login `sessions()` undefined → 503 + `text/plain` + `logger.error`。
+7. POST logout：revoke 被调 + set-cookie 含 `Max-Age=0` + 302；next 从 query（`?next=/x` → location `/x`）；无 body/无 content-type 可用；cookie 缺失也 302（幂等，M22）。
+8. GET status：有效 cookie → `{"authenticated":true}`；无 → false；带 `Authorization: Bearer` 头不影响结果（只认 cookie，M5）。
+9. method 分发：`DELETE /auth/login` → 405 + `allow: GET, POST`；`GET /auth/logout` → 405；`POST /auth/status` → 405。
+10. prefix `/auth` 兜底：`/auth/whatever` → 404 + no-store（M20）。
+11. 413：body 超限 → 413 + `connection: close` 头 + 不调 `req.destroy`（M19）。
+
+**`src/integration.auth.test.ts`**（真实入口路径）— 真实 cordis + **真实 storage 栈**
+（Storage → storage-json → storage-domain，挂载顺序同 M1 `integration.session.test.ts`；否则
+`sessions` 恒 undefined → 登录恒 503）+ 真实 WebServer + **结构型假
+credentials provider**（M18：`ctx.provide("credentials", { resolve: async (ref) => ref === "DSH_AUTH_TOKEN" ? { value: TEST_TOKEN, source: "test" } : undefined })`，
+**先于本插件挂载**；`TEST_TOKEN` 随机生成、永不进快照）+ 本插件（config `{ cookieSecure: false }`，http 无 TLS）：
+
+1. 全流程：`GET /auth/login` → 200；`POST /auth/login` 错 token → 401；对 token →
+   302 + `set-cookie` 头 + `location`；带 cookie `GET /__probe`（auth 之后注册的 exact 路由）→ 200；
+   无 cookie `GET /__probe` → 302（HTML accept）/ 401（JSON accept）；`Authorization: Bearer 对` → 200；
+   Bearer 错 → 401；`POST /auth/logout?next=/`（带 cookie，无 body）→ 302 + Max-Age=0；原 cookie 再访问 `/__probe` → 401。
+2. 白名单兜底：`GET /auth/whatever` → 404（非 SPA fallback）；`DELETE /auth/login` → 405。
+3. credentials 缺失（不挂 provider）→ 登录 401（resolver undefined）+ 启动日志 error。
+4. WS 通道：带会话 cookie 的 upgrade → 101（upgrade 事件）；`Authorization: Bearer <对>` 的 upgrade → 101；无凭证 upgrade → 401 拒握手（复用 M1 `requestUpgradeStatus` 模式，加 cookie/authorization 头变体）。
+5. 会话持久化已在 M1 `integration.session.test.ts` 覆盖（复用）。
+
+---
+
+## 6. 实施顺序（每步保持 `npm run verify` 绿）
+
+1. `session-store.ts` buildSetCookie 加参 + `session-store.test.ts` 补用例：`secure=false` 精确串
+   `dsh_auth=tok; Max-Age=604800; Path=/; HttpOnly; SameSite=Lax`、缺省第 4 参 → 原精确串不变（向后兼容）。
+2. `src/cookie.ts` + 测试。
+3. `src/token-gate.ts` + 测试。
+4. `src/form-body.ts` + 测试。
+5. `src/login-page.ts`（纯渲染，随 auth-endpoints 测试覆盖；可先写后测）。
+6. `src/auth-endpoints.ts` + 测试。
+7. `src/index.ts` 装配 + `src/index.test.ts` 适配（mode=password 抛错、credentials 缺失 fail-closed、gate 为 TokenGate 实例）。
+8. `src/integration.auth.test.ts`。
+9. `docs/development.md` Structure 树更新为：
+   ```
+   src/
+   ├── index.ts           # plugin entry + auth 服务接线 + credentials 解析器（M2 改装配）
+   ├── guard.ts           # 守卫包装/拒绝管线 + AUTH_PATH_PREFIX（M2 加常量）
+   ├── gate.ts            # Gate 词表 + noopGate（M2 换真门）
+   ├── token-gate.ts      # TokenGate：白名单/cookie/Bearer + safeEqual（M2 新增）
+   ├── cookie.ts          # Cookie 头解析（M2 新增）
+   ├── form-body.ts       # urlencoded body 读取（M2 新增）
+   ├── login-page.ts      # 自包含登录页（M2 新增）
+   ├── auth-endpoints.ts  # /auth 兜底前缀 + 三个 exact 端点（M2 新增）
+   ├── session-store.ts   # storage-domain 会话持久化（buildSetCookie 加参）
+   ├── self-check.ts      # 包装覆盖自检（fail loud）
+   ├── *.test.ts          # 单元测试（显式 vitest import）
+   └── integration.*.test.ts  # 真实 cordis/webserver/storage 栈集成测试
+   ```
+   `docs/handoff-m2_zh.md` 状态快照（§2）与 §5.4 冒烟序列同步更新。
+
+---
+
+## 7. Definition of Done
+
+1. `npm run verify` 全绿（format/lint/type-check/coverage ≥80%/lock:check）。
+2. `npm run build` + `lib/` 与 `src/` 同批；`git diff --exit-code -- lib` 通过。
+3. `npm run test -- src/integration.auth.test.ts src/integration.guard.test.ts src/integration.session.test.ts` 单独跑绿。
+4. **服务器端到端冒烟**（交接文档 §5 工作流，真实 LocalCredentialProvider）：overlay 加
+   `config: { cookieSecure: false }` + `$DSH_HOME/.credentials.yaml` 写 `DSH_AUTH_TOKEN: <测试值>`
+   （`chmod 600`）→ 重启实例 → curl 验证：未认证 `/__auth_probe` → 302/401；POST 登录 → Set-Cookie；
+   带 cookie → 200；Bearer → 200；`GET /auth/whatever` → 404（兜底）；WS upgrade 带 cookie → 101 /
+   无凭证 → 401。
+5. 报告：改动文件、M1–M22 落点、覆盖率数字、与本文档的偏差（应为零）。
+
+---
+
+## 8. 禁区清单
+
+- **不探索 harness 内部**（同 M1）；credentials 服务只经 §3.1 的结构类型。
+- **零新增依赖**（M18）：runtime 与 devDependencies 都不动——`node:crypto`/`URLSearchParams` 够用；
+  body 解析/HTML 渲染/cookie 解析全部手写；集成测试用结构型假 credentials provider，**不引入**
+  `dsh-credentials-local`。
+- **不把凭证落日志/快照**：token 值、session token 永不进日志/测试快照；`resolveToken` 失败只记错误消息。
+- **不吞认证失败**：登录失败必须 401（不是静默放行）；credentials 缺失必须 deny（fail-closed）。
+- **不动 M1 守卫行为**：`guard.ts` 仅新增 `AUTH_PATH_PREFIX` 常量（行为不变）；`gate.ts`/`self-check.ts`
+  不动（`noopGate` 保留导出）。
+- **不改门禁/tsconfig/eslint/vitest 配置**；不改依赖之外的 package.json。
+- **分支纪律**：`development`；未获指令不 commit/push。
+- M3/M4（users.yaml、argon2id、限速、TOTP、`dsh-auth user` CLI）**不做**——需要时只写 `TODO(auth-m3):` 注释。
+
+---
+
+## 9. 明确不做（M2 范围外）
+
+- users.yaml / 多凭证 / 口令登录 / argon2id / 登录限速（M3）。
+- TOTP 两段式登录（M4）。
+- 登录页美化 / 国际化 / client 半边登出按钮（GUI 组件）。
+- CSRF token（M14 注明，M3 评估）。
+- 部署侧交付物（正式 `cordis.patch.yml` 生产 patch、部署验收清单）——M2 代码验证后单独做。

--- a/docs/impl-m3.md
+++ b/docs/impl-m3.md
@@ -1,110 +1,124 @@
-# dsh-auth M3 实施规格（executable spec）
+# dsh-auth M3 Implementation Spec (executable spec)
 
-> 读者：执行实现的编码代理（预期 deepseek v4 flash，**新 session**）。本文档是**决策完备的规格**：
-> 所有判断点已预先关闭，执行者只做翻译，不做设计。
-> 基线：`docs/impl-m2.md`（M2 已交付：守卫 + TokenGate + /auth 端点 + 持久化会话——M3 在其上叠加）。
-> 设计依据：`docs/dsh-auth-plan.md` §5/§6 阶段 2/§8；工程门禁：`docs/development.md`。
-> **本文件是 M3 的唯一权威细则**；与 plan/M1/M2 冲突时以本文件为准。
+> Reader: the coding agent implementing this (expected deepseek v4 flash, **new session**). This document is a
+> **decision-complete spec**: all decision points are already closed; the executor only translates, it does not
+> design.
+> Baseline: `docs/impl-m2.md` (M2 delivered: guard + TokenGate + /auth endpoints + persistent sessions — M3 stacks
+> on top of it).
+> Design basis: `docs/dsh-auth-plan.md` §5/§6 phase 2/§8; engineering gates: `docs/development.md`.
+> **This file is the sole authority for M3 details**; where it conflicts with plan/M1/M2, this file wins.
 >
-> 环境与验证工作流见 `docs/handoff-m2.md`（新 session 必读：服务器访问、沙箱网络限制、M1/M2
-> 踩坑清单——§3/§4/§5 的环境事实对 M3 依然有效）。**禁止自行探索 harness 内部**——需要本文件
-> 之外的事实，停下报告。
+> Environment and verification workflow: see `docs/handoff-m2.md` (mandatory reading for a new session: server
+> access, sandbox network limits, M1/M2 pitfalls list — the §3/§4/§5 environment facts remain valid for M3).
+> **Do not explore the harness internals yourself** — if you need a fact not present in this file, stop and report.
 >
-> 已获用户确认的两个方向性决策（2026-08-15）：口令哈希用 **`node:crypto` scrypt**（零新增
-> 原生依赖）；password 模式下 **Bearer = 会话 token**（非共享 token、非 Basic）。
+> Two directional decisions already confirmed by the user (2026-08-15): password hashing uses **`node:crypto`
+> scrypt** (zero new native dependencies); in password mode **Bearer = session token** (not a shared token, not
+> Basic).
 
 ---
 
-## 1. M3 目标
+## 1. M3 Goals
 
-把阶段 2 的"真正登录"落地，`mode: "password"` 从抛错变为完整可用的密码流：
+Bring phase 2's "real login" to life: `mode: "password"` moves from throwing an error to a complete, usable
+password flow:
 
-- `$DSH_HOME/auth/users.yaml` 维护管理员凭证（scrypt 哈希，**文件里永不出现明文口令**）；
-- `POST /auth/login` 接受 `username` + `password`，恒时验证 → 发持久化会话 cookie（subject =
-  用户名，审计用）；错误口令/未知用户/禁用用户统一 401（防枚举）；
-- 登录限速：按 IP + 账号双桶计数，失败指数退避，锁定返回 `429 + retry-after`；
-- `Authorization: Bearer <会话 token>` 直接通过守卫（会话查表校验，零每请求 KDF）；
-- 配套 CLI：`dsh-auth user add/list/disable`（生成哈希、原子编辑 users.yaml）；
-- `mode: "token"`（M2 行为）**保持 100% 不变**，作为默认流继续可用。
+- `$DSH_HOME/auth/users.yaml` maintains administrator credentials (scrypt hashes, **plaintext passwords never
+  appear in the file**);
+- `POST /auth/login` accepts `username` + `password`, constant-time verification → issues a persistent session
+  cookie (subject = username, for auditing); wrong password / unknown user / disabled user all uniformly return
+  401 (anti-enumeration);
+- login rate limiting: dual buckets counted by IP + account, exponential backoff on failure, lockout returns
+  `429 + retry-after`;
+- `Authorization: Bearer <session token>` passes the guard directly (session lookup validation, zero per-request
+  KDF);
+- accompanying CLI: `dsh-auth user add/list/disable` (generates hashes, atomically edits users.yaml);
+- `mode: "token"` (M2 behavior) **stays 100% unchanged** and remains usable as the default flow.
 
-守卫/会话/自检全部复用 M1/M2，**不改其行为**；本里程碑只加密码流 + CLI。
-
----
-
-## 2. 冻结决策表（M3 增量；M1 的 D1–D16、M2 的 M1–M22 不变）
-
-| #   | 决策           | 冻结值                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
-| --- | -------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| P1  | 口令哈希       | `node:crypto` **scrypt**（`promisify(scrypt)`），参数 **N=65536, r=8, p=1, keylen=32**，salt = `randomBytes(16)`，**显式 `maxmem: 128 * 1024 * 1024`**（本机实测：N=2¹⁵ 即超过默认 32 MiB maxmem 直接抛 RangeError，必须显式传）。存储为单字符串 `scrypt$<N>$<r>$<p>$<salt b64url>$<hash b64url>`。单次派生 ~150 ms，登录低频可接受                                                                                                                                                                                                                                                                                                                                                                                                                                                |
-| P2  | 验证语义       | `verifyPassword(password, stored)` 解析 stored 的 N/r/p/salt/hash 后按**存储值**的参数重新派生（当前值即 P1，未来调参时旧哈希仍可验证）；N ≤ 2¹⁷、r ≤ 32、p ≤ 4（防 users 文件恶意参数放大内存），salt 段解码 16 字节、hash 段 32 字节，段数/前缀/数字不合法 → `false`（**不抛**）。恒时：`timingSafeEqual`（双方恒 32 字节 Buffer）                                                                                                                                                                                                                                                                                                                                                                                                                                               |
-| P3  | DUMMY_HASH     | 冻结字面量：`scrypt$65536$8$1$enp6enp6enp6enp6enp6eg$qhquFN2piwx7cxC6jYN4yREJCPln_GQTzBbLmm4bj1k`（salt = 16 个 0x7a 字节；口令 `dsh-auth-dummy-password-for-timing-uniformity` 仅出现在测试断言中，**不是秘密**）。未知用户名登录时对该常量跑一次真验证（时序均匀，防用户名枚举）                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 |
-| P4  | users 文件格式 | `$DSH_HOME/auth/users.yaml`：顶层 `{ version: 1, users: { <name>: { passwordHash, totpSecret?, disabled? } } }`。zod 严格校验：顶层与用户条目都 `.strict()`——未知键/`version` 非 1/非法用户名/缺失 `passwordHash` → 文件不可用（503）。`totpSecret`（可选 string）**M3 只解析不使用**（M4）；`disabled` 缺省 `false`                                                                                                                                                                                                                                                                                                                                                                                                                                                               |
-| P5  | username 约束  | `USERNAME_RE = /^[a-zA-Z0-9][a-zA-Z0-9._-]{0,63}$/`（users 文件校验 + CLI 强制）；匹配**大小写敏感**、不做任何规范化。用户名仅作键与审计 subject，不是身份边界                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     |
-| P6  | 文件路径       | config 新增 `usersFile: string`，默认 `""`。`""` 时 apply 内解析：`process.env.DSH_HOME` 存在 → `path.join(env, "auth", "users.yaml")`；否则 `path.join(os.homedir(), ".dsh", "auth", "users.yaml")`（与部署侧 `DSH_HOME=~/dsh-smoke` 启动方式一致，handoff §3.2）。显式 config 原样使用。解析规则是本插件自己的，README 注明                                                                                                                                                                                                                                                                                                                                                                                                                                                      |
-| P7  | 读取语义       | **每次登录尝试重新读文件**（per-operation，CLI 改完立即生效、免重启——与 M2 credentials 语义一致）；**不缓存**。YAML 语法错/schema 错/权限过宽 → 登录 503 `"user store unavailable"` + `log.error`（每次失败都记——登录低频，操作员信号）；文件不存在 → **空用户集** + 进程内首次 `log.warn` 一次（flag 防刷）+ 登录走 401 路径                                                                                                                                                                                                                                                                                                                                                                                                                                                      |
-| P8  | 文件权限       | 与 credentials 的 0600 纪律一致：POSIX 上加载时 `(stat.mode & 0o077) !== 0` → 文件不可用（503）；**win32 跳过检查**（权限无意义，CI 有 windows-latest）。CLI 写入一律 0600（P19）                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  |
-| P9  | 认证结果       | 未知用户 → 对 DUMMY_HASH 验证后 401；口令错误 → 401；`disabled: true` → **仍跑一次真验证**（时序均匀）后 401。三者响应体统一 `"invalid credentials"` + `logger.info("login rejected")`（**不含用户名**——防枚举，日志纪律 P23）                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     |
-| P10 | 登录限速       | 内存态 `LoginRateLimiter`（**重启清零**，README 注明）。常量：`maxFailures=5`、`baseDelaySeconds=30`、`maxDelaySeconds=900`、`windowSeconds=600`；第 n（n≥5）次失败 → 锁定 `min(30 * 2^(n-5), 900)` 秒。锁定期请求 → **429** + `retry-after: <秒>` + text/plain `"too many attempts"` + `logger.info("rate limit exceeded")`，**不增计数、不验证**；锁到期条目清零重计；**失败计数 10 分钟无失败后衰减清零**（滑动窗口，`windowSeconds`）；成功清双桶。IP 取 `req.socket.remoteAddress ?? ""`，**不读 XFF**（可伪造）；`username === ""` 只计 IP 桶；条目上限 10000，超限删最早插入                                                                                                                                                                                                |
-| P11 | mode 语义      | `mode: "password"` 激活 PasswordGate + password 端点（**不再抛错**）；`mode: "token"` 为默认且行为与 M2 **逐字节一致**（`token-gate.ts` 零改动、credentials 接线零改动）。两模式**二选一不可并存**；password 模式不读 credentials 服务、`tokenRef` 配置被忽略                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      |
-| P12 | PasswordGate   | `decide` 顺序：1) 白名单 `/auth`、`/auth/*` → allow；2) cookie：`parseCookieHeader` 非空且 `sessions()?.getByToken(...)` 命中 → allow；3) **Bearer = 会话 token**：`Authorization` 匹配 `/^Bearer\s+(.+)$/i` 后 `sessions()?.getByToken(value)` 命中 → allow（**不比对共享 token、不派生哈希**）；4) deny。同步返回（无 await）。HTTP 与 upgrade 同一 `decide`（guard 侧不变）                                                                                                                                                                                                                                                                                                                                                                                                     |
-| P13 | 登录页         | `login-page.ts` 新增 `passwordLoginPageHtml(next, error?)`：username（`<input type="text" name="username" autocomplete="username" required>`）+ password（`<input type="password" name="password" autocomplete="current-password" required autofocus>`）+ hidden next（escape）+ 同款内联样式。`loginPageHtml`（token 版）原样保留。`GET /auth/login` 恒渲染（不查会话、不重定向，M20 一致）                                                                                                                                                                                                                                                                                                                                                                                       |
-| P14 | 登录端点       | `POST /auth/login`（password 模式）字段 `username`/`password`/`next`，复用 `parseFormBody`（415/413 语义与 M2 完全一致）。成功 → `store.create(username, ttl*1000)` + `buildSetCookie` 4 参 + 302 next + `info("session issued")`。失败 → 401 `"invalid credentials"`；`loadUsers` 失败 → 503 `"user store unavailable"` + `error`；`sessions()` undefined → 503 `"session store unavailable"` + `error`（M2 文案）。429 见 P10。全程 no-store                                                                                                                                                                                                                                                                                                                                     |
-| P15 | 会话语义       | subject = **username**（审计：日志知道哪个凭证产生的会话；不是隔离）。**禁用用户只拦新登录**：已发会话在 TTL 内继续有效（README 注明局限；`revokeBySubject` 留 M4 评估，写 `TODO(auth-m4):`）。每次登录都是新会话（防固定，M6 语义延续）                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
-| P16 | 路由模型       | password 模式注册**同样的 4 条**（prefix `/auth` 404 兜底 + 3 exact），由 `index.ts` 按 mode 二选一装配（不同时注册两条相同 path——webserver 会抛重复）。logout/status 行为与 M2 **完全一致**：logout 仅 POST、next 仅 query、无 body 可幂等调用、`Max-Age=0`；status 仅 GET、**只认 cookie**（Bearer 会话 token 不参与——无状态通道不建会话）                                                                                                                                                                                                                                                                                                                                                                                                                                       |
-| P17 | validateNext   | 提取到新文件 `src/auth-common.ts` 导出；`auth-endpoints.ts` 删私有实现改 import（**行为不变**，M2 测试守护）；`password-endpoints.ts` 同样 import。M8/M20 校验规则逐字保留                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         |
-| P18 | CLI            | `package.json` 增 `"bin": { "dsh-auth": "lib/cli.js" }`；`src/cli.ts` 首行 shebang（tsc 原样保留）。命令面：`user add <name> [--password-stdin] [--disabled]` / `user list` / `user disable <name>`；全局 `--file <path>`（缺省 `defaultUsersFilePath()`）。`add` **要求 `--password-stdin`**（从 stdin 读一行，去尾部 `\r\n`；缺 flag → usage + exit 1）；name 不符 USERNAME_RE / 已存在 → stderr 错误 + exit 1；成功 `out("user <name> added")`。`list` 按用户名排序输出 `<name>` / `<name> (disabled)`（**永不输出哈希**）。`disable` 幂等（已禁用也成功）。未知命令/参数 → usage 到 stderr + exit 1。成功 exit 0。`main(argv, io): Promise<number>` 可注入 io（`out`/`err`/`readLine`）——**禁 `console.*`**，默认 io 用 `process.stdout/stderr.write` + `node:readline` 读一行 |
-| P19 | CLI 写文件     | 经 `writeUsersFile`：`yaml.stringify` 重写**全文件**（注释不保留——README 注明该文件归 CLI 管、勿手写注释）+ 同目录 `<path>.tmp` 写入 + `fs.rename` 原子替换 + mode `0o600`；目录不存在则 `mkdir -p`。序列化时用户按用户名字典序（**显式比较器**——eslint 规则）                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     |
-| P20 | 依赖变更       | runtime 增 **`yaml@^2.9.0`**（本机锁文件已有 2.9.0 传递依赖，公开 npm 源，`lock:check` 通过）；**无其他依赖变化**（devDependencies 不动；scrypt 是内建）。安装必须 `npm install --registry=https://registry.npmjs.org/`                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            |
-| P21 | CSRF 评估      | **M3 仍不加登录 CSRF token**。评估结论：单门模型无用户间隔离——登录 CSRF 唯一影响是会话 subject 审计值被污染（受害者以攻击者身份使用同一共享实例），无权限边界损失；`SameSite=Lax` + 现代浏览器第三方 Set-Cookie 限制进一步收窄；README 注明残余风险，M4 再评估。                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   |
-| P22 | 配置面         | M3 唯一新 config = `usersFile`（P6）。限速常量**不配置化**（`rate-limit.ts` 模块常量）；scrypt 参数不配置化。                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      |
-| P23 | 日志纪律       | 延续 M21：**永不落**口令/用户名（登录相关日志）/哈希/会话 token。password 模式日志事件：`login rejected`、`rate limit exceeded`、`session issued`、`logout`（info）；`user store unavailable: <error.message>`、`session store unavailable`（error）；`users file not found: <path>`（warn，进程内一次）。DUMMY_HASH 与 DUMMY 口令是公开常量不受限；CLI 输出（list、add 确认）不是日志                                                                                                                                                                                                                                                                                                                                                                                             |
-| P24 | 行数预算       | `password-login.ts`（登录 handler 逻辑，≤250）与 `password-endpoints.ts`（路由骨架 + logout/status + 405，≤250）拆两个文件。测试沿 M2 教训拆三个文件（矩阵 §5）。`cli.ts` 单文件 ≤250（usage 文本作文件内常量）                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    |
-| P25 | 测试参数       | 单测/集成测试一律用**真实 scrypt 参数**（不弱化、不注入假参数）；密码类套件预算 ≤10 次派生（每次 ~150 ms）。429 锁定（30s 起）会污染同实例后续登录——**429 场景用独立 ctx/端口实例**（集成测试单独 describe 起新栈），单测用注入时钟 `now`                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
-| P26 | 装配顺序       | `apply` 内：log → mode 分支（token：`makeTokenResolver` + TokenGate；password：PasswordGate + `usersPath` 解析 + `new LoginRateLimiter()` + `loadUsers`/`verify` 闭包）→ auth 对象一步成型（`sessions: () => auth.sessions` 闭包自引用）+ `provide` → storage 软接（M1 逻辑不动）→ `wrapServer` → 端点注册（按 mode 二选一，包装后的 `server.register`）→ 自检（最后）。apply 内无 await；password 模式**不访问 credentials 服务**                                                                                                                                                                                                                                                                                                                                                 |
+Guard/session/self-check all reuse M1/M2, **their behavior is not changed**; this milestone only adds the password
+flow + CLI.
 
 ---
 
-## 3. 权威契约（M3 新增事实；其余见 impl-m1.md §2 / impl-m2.md §3）
+## 2. Frozen decision table (M3 increments; M1's D1–D16 and M2's M1–M22 unchanged)
 
-### 3.1 `node:crypto` scrypt（本机 Node 24.13.1 实测）
-
-- `scrypt(password, salt, keylen, options)` 回调式；用 `promisify(scrypt)`。
-- **maxmem 实测**：默认 maxmem = 32 MiB；N=32768/r=8 即抛
-  `RangeError: Invalid scrypt params ... memory limit exceeded`——**必须显式 `maxmem`**（P1 冻结
-  128 MiB；N=65536/r=8 需要 64 MiB 工作内存，留余量）。
-- N=65536/r=8/p=1/keylen=32 实测 ~150 ms/次。
-- `timingSafeEqual` 只接受 Buffer/TypedArray（M2 已冻结，scrypt 输出即 Buffer，双方恒 32 字节）。
-- base64url 长度：16 字节 salt → 22 字符；32 字节 hash → 43 字符。存储串总长固定，格式正则
-  `/^scrypt\$65536\$8\$1\$[A-Za-z0-9_-]{22}\$[A-Za-z0-9_-]{43}$/`（当前参数下的形状断言用）。
-
-### 3.2 `yaml` 包（v2.9.0，公开 npm，已在本仓库锁文件传递依赖中）
-
-- `import { parse, stringify } from "yaml"`；`parse` 返回 `unknown`（不信任输入，一律过 zod 校验）；
-  `stringify` 默认 2 空格缩进、LF。仅用这两个 API，不用 schema/anchors 高级特性。
-- `parse` 对重复键默认**报错抛异常**（YAML 1.2 默认）——正是我们要的严格行为（重复用户名 = 文件
-  不可用）；测试覆盖。
-
-### 3.3 路径与进程环境
-
-- `process.env.DSH_HOME`：部署侧以 `DSH_HOME=~/dsh-smoke <dsh>` 方式启动（handoff §3.2 已验证的
-  机制）；本插件**只读**该变量做 P6 默认路径解析，不探索/不依赖 harness 的任何其他环境事实。
-- `os.homedir()` 兜底（跨平台）；CLI 与插件共享同一个 `defaultUsersFilePath()` 实现
-  （`users-file.ts`），保证 CLI 缺省 `--file` 与插件默认路径一致。
-
-### 3.4 不探索
-
-沿用 M1/M2 纪律：需要本文件未出现的事实（字段、签名、行为）→ 停下报告，不得猜测。
+| #   | Decision               | Frozen value                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     |
+| --- | ---------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| P1  | Password hash          | `node:crypto` **scrypt** (`promisify(scrypt)`), parameters **N=65536, r=8, p=1, keylen=32**, salt = `randomBytes(16)`, **explicit `maxmem: 128 * 1024 * 1024`** (measured on this machine: N=2¹⁵ already exceeds the default 32 MiB maxmem and throws RangeError directly, so it must be passed explicitly). Stored as a single string `scrypt$<N>$<r>$<p>$<salt b64url>$<hash b64url>`. Single derivation ~150 ms, acceptable for low-frequency login                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
+| P2  | Verification semantics | `verifyPassword(password, stored)` parses N/r/p/salt/hash from stored, then re-derives using the **stored** parameters (current value is P1; when tuning parameters in the future, old hashes still validate); N ≤ 2¹⁷, r ≤ 32, p ≤ 4 (prevents malicious parameters in a users file from amplifying memory), salt segment decodes to 16 bytes, hash segment to 32 bytes, invalid segment count/prefix/numbers → `false` (**no throw**). Constant-time: `timingSafeEqual` (both sides always 32-byte Buffers)                                                                                                                                                                                                                                                                                                                                                                                                                                                    |
+| P3  | DUMMY_HASH             | Frozen literal: `scrypt$65536$8$1$enp6enp6enp6enp6enp6eg$qhquFN2piwx7cxC6jYN4yREJCPln_GQTzBbLmm4bj1k` (salt = 16 bytes of 0x7a; the password `dsh-auth-dummy-password-for-timing-uniformity` appears only in test assertions and is **not a secret**). For an unknown user login, run one real verification against this constant (timing uniformity, anti-username-enumeration)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 |
+| P4  | Users file format      | `$DSH_HOME/auth/users.yaml`: top level `{ version: 1, users: { <name>: { passwordHash, totpSecret?, disabled? } } }`. zod strict validation: both the top level and user entries use `.strict()` — unknown key / `version` not 1 / invalid username / missing `passwordHash` → file unusable (503). `totpSecret` (optional string) is **parsed but not used** in M3 (M4); `disabled` defaults to `false`                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         |
+| P5  | username constraint    | `USERNAME_RE = /^[a-zA-Z0-9][a-zA-Z0-9._-]{0,63}$/` (users file validation + CLI enforcement); matching is **case-sensitive**, no normalization performed. Username is only a key and an audit subject, not an identity boundary                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 |
+| P6  | File path              | config adds `usersFile: string`, default `""`. When `""`, resolve inside apply: `process.env.DSH_HOME` exists → `path.join(env, "auth", "users.yaml")`; otherwise `path.join(os.homedir(), ".dsh", "auth", "users.yaml")` (consistent with the deploy-side `DSH_HOME=~/dsh-smoke` startup, handoff §3.2). An explicit config is used as-is. The resolution rule is this plugin's own; note it in the README                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      |
+| P7  | Read semantics         | **Re-read the file on every login attempt** (per-operation, CLI changes take effect immediately, no restart needed — consistent with the M2 credentials semantics); **no caching**. YAML syntax error / schema error / overly permissive permissions → login 503 `"user store unavailable"` + `log.error` (logged on every failure — login is low-frequency, operator signal); file absent → **empty user set** + one in-process `log.warn` on first occurrence (flag prevents flooding) + login takes the 401 path                                                                                                                                                                                                                                                                                                                                                                                                                                              |
+| P8  | File permissions       | Consistent with the 0600 discipline of credentials: on POSIX, at load time `(stat.mode & 0o077) !== 0` → file unusable (503); **win32 skips the check** (permissions are meaningless there; CI has windows-latest). CLI always writes 0600 (P19)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 |
+| P9  | Auth result            | Unknown user → verify against DUMMY_HASH then 401; wrong password → 401; `disabled: true` → **still run one real verification** (timing uniformity) then 401. All three share the response body `"invalid credentials"` + `logger.info("login rejected")` (**no username** — anti-enumeration, log discipline P23)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               |
+| P10 | Login rate limiting    | In-memory `LoginRateLimiter` (**reset on restart**, note in README). Constants: `maxFailures=5`, `baseDelaySeconds=30`, `maxDelaySeconds=900`, `windowSeconds=600`; the nth (n≥5) failure → lock for `min(30 * 2^(n-5), 900)` seconds. Request during the lock period → **429** + `retry-after: <seconds>` + text/plain `"too many attempts"` + `logger.info("rate limit exceeded")`, **does not increment counters, does not verify**; on lock expiry the entry is cleared and counted from zero; **failure count decays to zero if no failure occurs for 10 minutes** (sliding window, `windowSeconds`); success clears both buckets. IP is taken from `req.socket.remoteAddress ?? ""`, **XFF is not read** (forgeable); `username === ""` only counts the IP bucket; entry cap 10000, when exceeded delete the earliest inserted                                                                                                                             |
+| P11 | mode semantics         | `mode: "password"` activates PasswordGate + password endpoints (**no longer throws**); `mode: "token"` is the default and behaves **byte-for-byte** the same as M2 (`token-gate.ts` zero changes, credentials wiring zero changes). The two modes are **mutually exclusive, never simultaneous**; password mode does not read the credentials service, and the `tokenRef` configuration is ignored                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               |
+| P12 | PasswordGate           | `decide` order: 1) whitelist `/auth`, `/auth/*` → allow; 2) cookie: `parseCookieHeader` non-empty and `sessions()?.getByToken(...)` hits → allow; 3) **Bearer = session token**: `Authorization` matches `/^Bearer\s+(.+)$/i` then `sessions()?.getByToken(value)` hits → allow (**no comparison against the shared token, no hash derivation**); 4) deny. Synchronous return (no await). HTTP and upgrade share the same `decide` (guard side unchanged)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        |
+| P13 | Login page             | `login-page.ts` adds `passwordLoginPageHtml(next, error?)`: username (`<input type="text" name="username" autocomplete="username" required>`) + password (`<input type="password" name="password" autocomplete="current-password" required autofocus>`) + hidden next (escaped) + the same inline styles. `loginPageHtml` (token version) is preserved as-is. `GET /auth/login` always renders (no session check, no redirect, consistent with M20)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              |
+| P14 | Login endpoint         | `POST /auth/login` (password mode) accepts fields `username`/`password`/`next`, reuses `parseFormBody` (415/413 semantics exactly like M2). Success → `store.create(username, ttl*1000)` + `buildSetCookie` 4 args + 302 next + `info("session issued")`. Failure → 401 `"invalid credentials"`; `loadUsers` failure → 503 `"user store unavailable"` + `error`; `sessions()` undefined → 503 `"session store unavailable"` + `error` (M2 wording). 429 see P10. no-store throughout                                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
+| P15 | Session semantics      | subject = **username** (auditing: logs know which credential produced the session; not an isolation boundary). **Disabled users only block new logins**: already-issued sessions remain valid within their TTL (note the limitation in README; `revokeBySubject` is left for M4 evaluation, written as `TODO(auth-m4):`). Every login is a new session (anti-fixation, M6 semantics continue)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    |
+| P16 | Route model            | password mode registers **the same 4** (prefix `/auth` 404 fallback + 3 exact), assembled by `index.ts` as a choice of one based on mode (never register two identical paths — webserver would throw on duplicates). logout/status behavior is **exactly identical** to M2: logout is POST-only, next is query-only, invokable without body idempotently, `Max-Age=0`; status is GET-only, **only recognizes the cookie** (Bearer session token does not participate — a stateless channel does not create sessions)                                                                                                                                                                                                                                                                                                                                                                                                                                             |
+| P17 | validateNext           | Extracted to a new file `src/auth-common.ts` and exported; `auth-endpoints.ts` removes the private implementation and changes to import (**behavior unchanged**, guarded by M2 tests); `password-endpoints.ts` imports it as well. M8/M20 validation rules preserved verbatim                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    |
+| P18 | CLI                    | `package.json` adds `"bin": { "dsh-auth": "lib/cli.js" }`; `src/cli.ts` has a shebang first line (tsc preserves it as-is). Command surface: `user add <name> [--password-stdin] [--disabled]` / `user list` / `user disable <name>`; global `--file <path>` (default `defaultUsersFilePath()`). `add` **requires `--password-stdin`** (reads one line from stdin, strips trailing `\r\n`; missing flag → usage + exit 1); name not matching USERNAME_RE / already exists → stderr error + exit 1; success `out("user <name> added")`. `list` outputs `<name>` / `<name> (disabled)` sorted by username (**never outputs hashes**). `disable` is idempotent (succeeds even if already disabled). Unknown command/argument → usage to stderr + exit 1. Success exit 0. `main(argv, io): Promise<number>` with injectable io (`out`/`err`/`readLine`) — **`console.*` forbidden**, default io uses `process.stdout/stderr.write` + `node:readline` to read one line |
+| P19 | CLI file writing       | Via `writeUsersFile`: `yaml.stringify` rewrites the **whole file** (comments are not preserved — note in README that the file is managed by the CLI, don't hand-write comments) + write to `<path>.tmp` in the same directory + `fs.rename` atomic replace + mode `0o600`; `mkdir -p` if the directory does not exist. On serialization, users are ordered lexicographically by username (**explicit comparator** — eslint rule)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 |
+| P20 | Dependency changes     | runtime adds **`yaml@^2.9.0`** (this machine's lockfile already has 2.9.0 as a transitive dependency, public npm source, `lock:check` passes); **no other dependency changes** (devDependencies untouched; scrypt is built-in). Install must use `npm install --registry=https://registry.npmjs.org/`                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            |
+| P21 | CSRF evaluation        | **M3 still does not add a login CSRF token.** Evaluation conclusion: the single-gate model has no inter-user isolation — the only impact of login CSRF is that the session subject audit value is polluted (victim uses the same shared instance as the attacker), no permission boundary is lost; `SameSite=Lax` plus modern-browser third-party Set-Cookie restrictions narrow it further; note the residual risk in the README, re-evaluate in M4.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            |
+| P22 | Config surface         | The only new M3 config = `usersFile` (P6). Rate-limit constants are **not configurable** (`rate-limit.ts` module constants); scrypt parameters are not configurable.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
+| P23 | Log discipline         | Continuation of M21: **never log** passwords/usernames (login-related logs)/hashes/session tokens. Password-mode log events: `login rejected`, `rate limit exceeded`, `session issued`, `logout` (info); `user store unavailable: <error.message>`, `session store unavailable` (error); `users file not found: <path>` (warn, once per process). DUMMY_HASH and the DUMMY password are public constants, not restricted; CLI output (list, add confirmation) is not logging                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     |
+| P24 | Line budget            | `password-login.ts` (login handler logic, ≤250) and `password-endpoints.ts` (route skeleton + logout/status + 405, ≤250) split into two files. Tests split into three files following the M2 lesson (matrix §5). `cli.ts` is a single file ≤250 (usage text as an in-file constant)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              |
+| P25 | Test parameters        | Unit/integration tests all use **real scrypt parameters** (no weakening, no fake injected parameters); the password-class suites budget ≤10 derivations (each ~150 ms). 429 lockout (from 30s) pollutes subsequent logins on the same instance — **429 scenarios use a standalone ctx/port instance** (integration tests start a new stack in a separate describe), unit tests use an injected clock `now`                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
+| P26 | Assembly order         | Inside `apply`: log → mode branch (token: `makeTokenResolver` + TokenGate; password: PasswordGate + `usersPath` resolution + `new LoginRateLimiter()` + `loadUsers`/`verify` closures) → auth object formed in one step (`sessions: () => auth.sessions` closure self-reference) + `provide` → storage soft-wiring (M1 logic unchanged) → `wrapServer` → endpoint registration (choose one of two by mode, using the wrapped `server.register`) → self-check (last). No await inside apply; password mode **does not access the credentials service**                                                                                                                                                                                                                                                                                                                                                                                                            |
 
 ---
 
-## 4. 文件蓝图
+## 3. Authoritative contracts (new M3 facts; the rest see impl-m1.md §2 / impl-m2.md §3)
 
-每个文件 ≤250 行、函数 ≤80 行、复杂度 ≤15（ESLint error）。M2 文件改动只有三处：
-`auth-endpoints.ts`（P17 import）、`login-page.ts`（新增一个导出）、`index.ts`（P26 装配）。
+### 3.1 `node:crypto` scrypt (measured on this machine with Node 24.13.1)
+
+- `scrypt(password, salt, keylen, options)` is callback-based; use `promisify(scrypt)`.
+- **maxmem measured**: default maxmem = 32 MiB; N=32768/r=8 already throws
+  `RangeError: Invalid scrypt params ... memory limit exceeded` — **must pass explicit `maxmem`** (P1 freezes
+  128 MiB; N=65536/r=8 needs 64 MiB working memory, leaving headroom).
+- N=65536/r=8/p=1/keylen=32 measured ~150 ms/op.
+- `timingSafeEqual` only accepts Buffer/TypedArray (already frozen in M2; scrypt output is a Buffer, both sides
+  always 32 bytes).
+- base64url lengths: 16-byte salt → 22 characters; 32-byte hash → 43 characters. The stored string's total length
+  is fixed; shape regex `/^scrypt\$65536\$8\$1\$[A-Za-z0-9_-]{22}\$[A-Za-z0-9_-]{43}$/` (for asserting the shape
+  under current parameters).
+
+### 3.2 `yaml` package (v2.9.0, public npm, already a transitive dependency in this repo's lockfile)
+
+- `import { parse, stringify } from "yaml"`; `parse` returns `unknown` (do not trust input, always pass through
+  zod validation); `stringify` defaults to 2-space indent, LF. Use only these two APIs, not schema/anchor advanced
+  features.
+- `parse` **throws an error by default on duplicate keys** (YAML 1.2 default) — exactly the strict behavior we
+  want (duplicate username = file unusable); covered by tests.
+
+### 3.3 Paths and process environment
+
+- `process.env.DSH_HOME`: the deploy side starts with `DSH_HOME=~/dsh-smoke <dsh>` (mechanism verified in handoff
+  §3.2); this plugin **only reads** this variable to resolve the P6 default path, and does not explore or depend on
+  any other harness environment fact.
+- `os.homedir()` fallback (cross-platform); CLI and the plugin share the same `defaultUsersFilePath()`
+  implementation (`users-file.ts`), guaranteeing the CLI's default `--file` and the plugin's default path match.
+
+### 3.4 No exploration
+
+Following the M1/M2 discipline: if you need a fact not present in this file (field, signature, behavior) → stop
+and report; do not guess.
+
+---
+
+## 4. File blueprints
+
+Each file ≤250 lines, function ≤80 lines, complexity ≤15 (ESLint error). M2 file changes are only in three places:
+`auth-endpoints.ts` (P17 import), `login-page.ts` (one new export), `index.ts` (P26 assembly).
 `token-gate.ts` / `cookie.ts` / `form-body.ts` / `guard.ts` / `gate.ts` / `session-store.ts` /
-`self-check.ts` **零改动**。
+`self-check.ts` **zero changes**.
 
-### 4.1 `src/password.ts` —— scrypt 哈希与恒时验证
+### 4.1 `src/password.ts` — scrypt hashing and constant-time verification
 
 ```ts
 import { randomBytes, scrypt as scryptCb, timingSafeEqual } from "node:crypto";
@@ -116,32 +130,33 @@ export const SCRYPT_R = 8;
 export const SCRYPT_P = 1;
 export const SCRYPT_KEYLEN = 32;
 export const SCRYPT_MAXMEM = 128 * 1024 * 1024;
-/** 未知用户登录时的占位哈希（P3）：salt=16×0x7a 的固定常量，验证成本与真用户一致。 */
+/** Placeholder hash for unknown-user logins (P3): a fixed constant with salt=16×0x7a, verification cost equal to a real user. */
 export const DUMMY_HASH =
   "scrypt$65536$8$1$enp6enp6enp6enp6enp6eg$qhquFN2piwx7cxC6jYN4yREJCPln_GQTzBbLmm4bj1k";
 
-/** 生成 `scrypt$<N>$<r>$<p>$<salt b64url>$<hash b64url>`（salt 16 字节随机）。 */
+/** Generate `scrypt$<N>$<r>$<p>$<salt b64url>$<hash b64url>` (salt is 16 random bytes). */
 export async function hashPassword(password: string): Promise<string>;
 
-/** 恒时验证：解析 stored 参数后重派生（P2），格式/参数非法 → false，不抛。 */
+/** Constant-time verification: parse stored parameters and re-derive (P2); invalid format/params → false, no throw. */
 export async function verifyPassword(password: string, stored: string): Promise<boolean>;
 ```
 
-行为约定：`hashPassword` 先 `randomBytes(16)` 再 `scrypt`，拼接用当前常量参数。`verifyPassword`
-先 `stored.split("$")`：6 段、段 0 === `"scrypt"`、N/r/p 为正整数且 N ≤ 2¹⁷、r ≤ 32、p ≤ 4、
-salt/hash 段 base64url 解码后 16/32 字节——任一不满足 → `false`；按**解析出的**参数
-`scrypt(password, salt, 32, { N, r, p, maxmem: SCRYPT_MAXMEM })` 后 `timingSafeEqual`。派生异常
-（内存不足等）→ catch 后 `false`。
+Behavior contract: `hashPassword` first does `randomBytes(16)` then `scrypt`, concatenating with the current
+constant parameters. `verifyPassword` first does `stored.split("$")`: 6 segments, segment 0 === `"scrypt"`, N/r/p
+are positive integers with N ≤ 2¹⁷, r ≤ 32, p ≤ 4, the salt/hash segments decode from base64url to 16/32
+bytes — any failure → `false`; then with the **parsed** parameters run
+`scrypt(password, salt, 32, { N, r, p, maxmem: SCRYPT_MAXMEM })` followed by `timingSafeEqual`. A derivation
+exception (e.g. out of memory) → catch and return `false`.
 
-### 4.2 `src/rate-limit.ts` —— 双桶登录限速
+### 4.2 `src/rate-limit.ts` — dual-bucket login rate limiting
 
 ```ts
 export interface RateLimitOptions {
-  maxFailures?: number; // 默认 5
-  baseDelaySeconds?: number; // 默认 30
-  maxDelaySeconds?: number; // 默认 900
-  windowSeconds?: number; // 默认 600：失败计数衰减窗口（见下）
-  now?: () => number; // 默认 Date.now；测试注入
+  maxFailures?: number; // default 5
+  baseDelaySeconds?: number; // default 30
+  maxDelaySeconds?: number; // default 900
+  windowSeconds?: number; // default 600: failure-count decay window (see below)
+  now?: () => number; // default Date.now; injected in tests
 }
 
 export type RateLimitCheck = { allowed: true } | { allowed: false; retryAfterSeconds: number };
@@ -154,21 +169,23 @@ export class LoginRateLimiter {
 }
 ```
 
-行为约定：
+Behavior contract:
 
-- 内部两个 `Map<string, { failures: number; lockUntil: number; lastFailureAt: number }>`
-  （`byIp` / `byAccount`）；`account === undefined || account === ""` 时只动 IP 桶。
-- `check`：任一桶 `lockUntil > now` → `{ allowed: false, retryAfterSeconds: max(1, ceil((lockUntil-now)/1000)) }`
-  （取两桶最大）；`lockUntil <= now` 且 failures > 0 → 清零（锁到期自然重试）；**失败衰减**：
-  failures > 0 且 `now - lastFailureAt > windowSeconds * 1000` → 清零（1–4 次失败 10 分钟无后续
-  失败即遗忘，防慢泄漏）；同时修剪：删除 `failures === 0` 的条目；总条目数 > 10000 → 删除
-  **最早插入**的（Map 迭代序）直到 ≤ 10000。
-- `recordFailure`：对应桶 `failures++`、`lastFailureAt = now`；若 `failures >= maxFailures` →
-  `lockUntil = now + min(baseDelay * 2 ** (failures - maxFailures), maxDelay) * 1000`。
-- `recordSuccess`：删除对应桶条目。
-- 端点锁定期**不调** `recordFailure`（429 短路，P10）——锁定时长由失败序列决定，不被延长。
+- Internally two `Map<string, { failures: number; lockUntil: number; lastFailureAt: number }>`
+  (`byIp` / `byAccount`); when `account === undefined || account === ""` only the IP bucket is touched.
+- `check`: if either bucket has `lockUntil > now` → `{ allowed: false, retryAfterSeconds: max(1, ceil((lockUntil-now)/1000)) }`
+  (take the max of the two buckets); when `lockUntil <= now` and failures > 0 → clear (lock expiry naturally
+  retries); **failure decay**: failures > 0 and `now - lastFailureAt > windowSeconds * 1000` → clear (1–4 failures
+  with no further failure for 10 minutes are forgotten, preventing slow leakage); simultaneously prune: delete
+  entries with `failures === 0`; if total entries > 10000 → delete the **earliest inserted** (Map iteration order)
+  until ≤ 10000.
+- `recordFailure`: increment `failures` for the bucket, `lastFailureAt = now`; if `failures >= maxFailures` →
+  `lockUntil = now + min(baseDelay * 2 ** (failures - maxFailures), maxDelay) * 1000`.
+- `recordSuccess`: delete the bucket entry.
+- The endpoint does **not** call `recordFailure` during the lock period (429 short-circuit, P10) — the lock duration
+  is determined by the failure sequence and is not extended.
 
-### 4.3 `src/users-file.ts` —— users.yaml 加载/校验/原子写
+### 4.3 `src/users-file.ts` — users.yaml load/validate/atomic write
 
 ```ts
 import { z } from "zod";
@@ -178,7 +195,7 @@ export const USERNAME_RE = /^[a-zA-Z0-9][a-zA-Z0-9._-]{0,63}$/;
 
 export interface UserRecord {
   passwordHash: string;
-  totpSecret?: string; // M3 解析不使用（M4）
+  totpSecret?: string; // parsed in M3 but not used (M4)
   disabled: boolean;
 }
 
@@ -186,32 +203,32 @@ export interface UsersSnapshot {
   users: Map<string, UserRecord>;
 }
 
-/** users 文件不可用（语法/schema/权限）。message 面向操作员，可落日志。 */
+/** The users file is unusable (syntax/schema/permissions). message is operator-facing, safe to log. */
 export class UsersFileError extends Error {}
 
-/** 加载结果：`missing` 区分"文件不存在"与"文件存在但无用户"（供 warn-once，P7）。 */
+/** Load result: `missing` distinguishes "file absent" from "file present but no users" (for warn-once, P7). */
 export interface UsersLoadResult {
   snapshot: UsersSnapshot;
-  missing: boolean; // ENOENT → true（快照为空）；解析/权限失败 → throw，不走此通道
+  missing: boolean; // ENOENT → true (snapshot empty); parse/permission failure → throw, does not go through this channel
 }
 
-/** P6：DSH_HOME env → ~/.dsh/auth/users.yaml。 */
+/** P6: DSH_HOME env → ~/.dsh/auth/users.yaml. */
 export function defaultUsersFilePath(): string;
 
-/** 每次登录现读（P7）。ENOENT → `{ snapshot: 空, missing: true }`（不抛）；否则 P7/P8 失败语义。 */
+/** Read fresh on every login (P7). ENOENT → `{ snapshot: empty, missing: true }` (no throw); otherwise P7/P8 failure semantics. */
 export async function loadUsersFile(path: string): Promise<UsersLoadResult>;
 
-/** CLI 用：全量序列化 + 原子替换 + 0600（P19）。 */
+/** CLI use: full serialization + atomic replace + 0600 (P19). */
 export async function writeUsersFile(path: string, snapshot: UsersSnapshot): Promise<void>;
 ```
 
-行为约定：
+Behavior contract:
 
-- `loadUsersFile`：`fs.stat` → ENOENT → 返回 `{ snapshot: 空快照, missing: true }`（**不抛**）；
-  POSIX 且 `(mode & 0o077) !== 0` →
-  throw `UsersFileError("users file has insecure permissions: <path>")`；win32 跳过权限检查。
-  `readFile("utf8")` → `parseYaml` → zod 校验。zod schema（v4，`z.object({...}).strict()` 顶层与
-  用户条目都 strict）：
+- `loadUsersFile`: `fs.stat` → ENOENT → return `{ snapshot: empty snapshot, missing: true }` (**no throw**);
+  POSIX and `(mode & 0o077) !== 0` →
+  throw `UsersFileError("users file has insecure permissions: <path>")`; win32 skips the permission check.
+  `readFile("utf8")` → `parseYaml` → zod validation. zod schema (v4, `z.object({...}).strict()` strict at both
+  top level and user entries):
   ```ts
   const userRecordSchema = z
     .object({
@@ -227,15 +244,15 @@ export async function writeUsersFile(path: string, snapshot: UsersSnapshot): Pro
     })
     .strict();
   ```
-  解析/校验失败 → throw `UsersFileError(<yaml 或 zod 的消息前缀 "invalid users file">)`；
-  用户名逐一 `USERNAME_RE` 校验（`superRefine` 或 load 后循环）——非法即 throw。成功后
-  `Map`（`disabled` 补 `false`），返回 `{ snapshot, missing: false }`。yaml parse 抛错（含重复键）
-  → 同样包装为 `UsersFileError`。
-- `writeUsersFile`：`mkdir(dirname, { recursive: true })` → `stringify({ version: 1, users: 对象 })`
-  （用户按用户名字典序，**显式比较器** `(a, b) => (a < b ? -1 : a > b ? 1 : 0)`）→
-  `writeFile(path + ".tmp", text, { mode: 0o600 })` → `rename` → 目标路径。幂等可重复调用。
+  Parse/validation failure → throw `UsersFileError(<prefix "invalid users file" from the yaml or zod message>)`;
+  each username validated against `USERNAME_RE` one by one (`superRefine` or a loop after load) — invalid → throw.
+  On success, build a `Map` (fill in `false` for `disabled`), return `{ snapshot, missing: false }`. A yaml parse
+  error (including duplicate keys) → likewise wrapped as `UsersFileError`.
+- `writeUsersFile`: `mkdir(dirname, { recursive: true })` → `stringify({ version: 1, users: object })`
+  (users in lexicographic order by username, **explicit comparator** `(a, b) => (a < b ? -1 : a > b ? 1 : 0)`) →
+  `writeFile(path + ".tmp", text, { mode: 0o600 })` → `rename` → target path. Idempotent, repeatable.
 
-### 4.4 `src/password-gate.ts` —— password 模式门
+### 4.4 `src/password-gate.ts` — password-mode gate
 
 ```ts
 import type { IncomingMessage } from "node:http";
@@ -245,7 +262,7 @@ import { AUTH_PATH_PREFIX } from "./guard.js";
 import { parseCookieHeader } from "./cookie.js";
 
 export interface PasswordGateOptions {
-  sessions: () => SessionStore | undefined; // M16 同形访问器
+  sessions: () => SessionStore | undefined; // M16-shaped accessor
   cookieName: string;
 }
 
@@ -255,33 +272,35 @@ export class PasswordGate implements Gate {
 }
 ```
 
-`decide` 顺序照 P12 实现（白名单 → cookie 会话 → Bearer 会话 token → deny）；**同步返回**，无
-async、无 KDF、无文件 IO。`sessions()` 返回 undefined 时 cookie 与 bearer 通道都跳过 → deny
-（与 M2 一致：会话层不可用时门恒 deny，白名单除外）。`kind` 参数沿用 `Gate` 接口（password 门
-不使用，签名一致）。
+`decide` order implements P12 (whitelist → cookie session → Bearer session token → deny); **synchronous return**,
+no async, no KDF, no file IO. When `sessions()` returns undefined, both the cookie and bearer channels are skipped
+→ deny (consistent with M2: when the session layer is unavailable the gate always denies, except the whitelist).
+The `kind` parameter follows the `Gate` interface (not used by the password gate, signature consistent).
 
-### 4.5 `src/auth-common.ts` —— 端点共享纯函数
+### 4.5 `src/auth-common.ts` — pure functions shared by endpoints
 
 ```ts
-/** M8+M20 逐字保留：单个 `/` 开头、非 `//`、无 `\`、非 /auth*；否则回落 `/`。 */
+/** M8+M20 preserved verbatim: starts with a single `/`, not `//`, no `\`, not /auth*; otherwise fall back to `/`. */
 export function validateNext(next: string): string;
 ```
 
-仅此一个导出。`auth-endpoints.ts` 删掉私有实现（L176–187），改 `import { validateNext } from "./auth-common.js"`；
-`queryOf`/`methodNotAllowed` 留在各自文件（不提取）。本文件无独立测试文件——由两端点套件覆盖
-（覆盖率达标即可）。
+Only this one export. `auth-endpoints.ts` removes its private implementation (L176–187) and changes to
+`import { validateNext } from "./auth-common.js"`; `queryOf`/`methodNotAllowed` stay in their own files (not
+extracted). This file has no standalone test file — covered by both endpoint suites (coverage reaching the target
+is enough).
 
-### 4.6 `src/login-page.ts` —— 新增 password 变体
+### 4.6 `src/login-page.ts` — new password variant
 
 ```ts
-/** password 模式登录页：username + password 两字段（P13）；next/error 全部 HTML-escape。 */
+/** password-mode login page: username + password two fields (P13); all next/error HTML-escaped. */
 export function passwordLoginPageHtml(next: string, error?: string): string;
 ```
 
-复用文件内 `escapeHtml` 与同款样式块（可提取文件内私有模板函数，但导出只增这一个）。token 版
-`loginPageHtml` **原样保留**。标题与按钮文案 `Sign in`（区别于 token 版 `Unlock`）。
+Reuses the in-file `escapeHtml` and the same style block (an in-file private template function may be extracted,
+but only this one export is added). The token version `loginPageHtml` is **preserved as-is**. Title and button
+text `Sign in` (distinct from the token version's `Unlock`).
 
-### 4.7 `src/password-login.ts` —— POST /auth/login 处理逻辑
+### 4.7 `src/password-login.ts` — POST /auth/login handler logic
 
 ```ts
 import type { IncomingMessage, ServerResponse } from "node:http";
@@ -293,10 +312,10 @@ export interface PasswordLoginDeps {
   sessions: () => SessionStore | undefined;
   cookieName: string;
   cookieSecure: boolean;
-  sessionTtl: number; // 秒
-  usersPath: string; // 仅用于"文件缺失"warn 消息（P23）
-  loadUsers: () => Promise<UsersLoadResult>; // index.ts 注入 loadUsersFile(usersPath) 闭包
-  verify: (password: string, storedHash: string) => Promise<boolean>; // 与 verifyPassword 同形，index.ts 直接注入
+  sessionTtl: number; // seconds
+  usersPath: string; // only used for the "file missing" warn message (P23)
+  loadUsers: () => Promise<UsersLoadResult>; // index.ts injects the loadUsersFile(usersPath) closure
+  verify: (password: string, storedHash: string) => Promise<boolean>; // same shape as verifyPassword, injected directly by index.ts
   limiter: LoginRateLimiter;
   logger: {
     error(message: unknown): void;
@@ -305,7 +324,7 @@ export interface PasswordLoginDeps {
   };
 }
 
-/** POST /auth/login（password 模式）。完成全部响应写出（含 415/413/401/429/503/302）。 */
+/** POST /auth/login (password mode). Completes the entire response write (including 415/413/401/429/503/302). */
 export async function handlePasswordLogin(
   deps: PasswordLoginDeps,
   req: IncomingMessage,
@@ -313,36 +332,37 @@ export async function handlePasswordLogin(
 ): Promise<void>;
 ```
 
-流程照此实现（顺序冻结，不得重排）：
+Flow implements this exactly (order frozen, must not be rearranged):
 
-1. `parseFormBody(req)`——带 `status` 的错误（415/413）→ 写对应响应（413 先
-   `res.setHeader("connection", "close")`，M19 复刻）；**不带 `status` 的异常向上抛**。
-2. `username = params.get("username") ?? ""`；`password = params.get("password") ?? ""`；
-   `next = validateNext(params.get("next") ?? "/")`；`ip = req.socket.remoteAddress ?? ""`。
-3. `const check = deps.limiter.check(ip, username === "" ? undefined : username)`；
-   锁定 → `429` + `retry-after: <check.retryAfterSeconds>` + text/plain `"too many attempts"` +
-   no-store + `info("rate limit exceeded")`；**return（不验证、不增计数）**。
+1. `parseFormBody(req)` — error carrying `status` (415/413) → write the corresponding response (for 413 first
+   `res.setHeader("connection", "close")`, replicating M19); **an exception without `status` propagates upward**.
+2. `username = params.get("username") ?? ""`; `password = params.get("password") ?? ""`;
+   `next = validateNext(params.get("next") ?? "/")`; `ip = req.socket.remoteAddress ?? ""`.
+3. `const check = deps.limiter.check(ip, username === "" ? undefined : username)`;
+   locked → `429` + `retry-after: <check.retryAfterSeconds>` + text/plain `"too many attempts"` +
+   no-store + `info("rate limit exceeded")`; **return (no verify, no counter increment)**.
 4. `let users: UsersSnapshot; let missing = false;` `try { const loaded = await deps.loadUsers(); users = loaded.snapshot; missing = loaded.missing; } catch (error) {`
    → 503 `"user store unavailable"` + no-store +
-   `error("user store unavailable: " + (error instanceof Error ? error.message : String(error)))`；
-   **return（系统错误不计失败）**。`}`
+   `error("user store unavailable: " + (error instanceof Error ? error.message : String(error)))`;
+   **return (system error does not count as a failure)**. `}`
    `if (missing && !warnedMissing) { warnedMissing = true; deps.logger.warn("users file not found: " + deps.usersPath + " (all password logins rejected)"); }`
-   （`warnedMissing` 为 handlePasswordLogin 模块级 flag——插件单实例，等价进程级一次；P7/P23。）
+   (`warnedMissing` is a module-level flag of `handlePasswordLogin` — the plugin is a single instance, equivalent
+   to once per process; P7/P23.)
 5. `const user = users.users.get(username);`
-   `const ok = await deps.verify(password, user?.passwordHash ?? DUMMY_HASH);`（DUMMY_HASH 从
-   `./password.js` import——未知用户时序均匀，P3。**注意参数顺序与 verifyPassword 同形
-   `(password, storedHash)`**——TS 结构兼容不检查参数名，顺序写反会在真实路径恒 401，实施时
-   已踩并修正）。
+   `const ok = await deps.verify(password, user?.passwordHash ?? DUMMY_HASH);` (DUMMY_HASH imported from
+   `./password.js` — timing-uniform for unknown users, P3. **Note the argument order is the same shape as
+   `verifyPassword` `(password, storedHash)`** — TS structural compatibility does not check argument names;
+   reversed order would always 401 on the real path, which was hit and corrected during implementation).
 6. `if (!ok || user === undefined || user.disabled) { deps.limiter.recordFailure(ip, username === "" ? undefined : username);`
-   → 401 `"invalid credentials"` + no-store + `info("login rejected")`；return。`}`。
+   → 401 `"invalid credentials"` + no-store + `info("login rejected")`; return. `}`.
 7. `deps.limiter.recordSuccess(ip, username === "" ? undefined : username);`
 8. `const store = deps.sessions();` undefined → 503 `"session store unavailable"` + no-store +
-   `error("login failed: session store unavailable")`；return。
+   `error("login failed: session store unavailable")`; return.
 9. `const { token: sessionToken } = await store.create(username, deps.sessionTtl * 1000);` →
-   `set-cookie`（`buildSetCookie(deps.cookieName, sessionToken, deps.sessionTtl, deps.cookieSecure)`）
-   - 302 `{ location: next }` + no-store + `info("session issued")`。
+   `set-cookie` (`buildSetCookie(deps.cookieName, sessionToken, deps.sessionTtl, deps.cookieSecure)`)
+   - 302 `{ location: next }` + no-store + `info("session issued")`.
 
-### 4.8 `src/password-endpoints.ts` —— password 模式路由骨架
+### 4.8 `src/password-endpoints.ts` — password-mode route skeleton
 
 ```ts
 import { AUTH_PATH_PREFIX, type HttpHandler } from "./guard.js";
@@ -353,92 +373,94 @@ import { validateNext } from "./auth-common.js";
 import { handlePasswordLogin, type PasswordLoginDeps } from "./password-login.js";
 
 export interface PasswordEndpointsDeps extends PasswordLoginDeps {
-  /** 注册路由（index.ts 传入包装后的 server.register；被守卫包装但被 gate 白名单放行）。 */
+  /** Register routes (index.ts passes the wrapped server.register; wrapped by the guard but let through by the gate whitelist). */
   register(route: { kind: "exact" | "prefix"; path: string; handler: HttpHandler }): () => void;
 }
 
-/** 注册 prefix `/auth` 兜底 + 三个 exact 端点（password 模式）；返回合并 disposer。 */
+/** Register prefix `/auth` fallback + three exact endpoints (password mode); return a merged disposer. */
 export function registerPasswordEndpoints(deps: PasswordEndpointsDeps): () => void;
 ```
 
-结构照 `auth-endpoints.ts`（合并 disposer、track 收集）：4 条路由——
+Structure follows `auth-endpoints.ts` (merged disposer, track collection): 4 routes —
 
-- prefix `/auth` → 恒 404 `"not found"` + no-store（P16）。
-- exact `/auth/login`：GET → `validateNext(query.get("next") ?? "/")` + 200 text/html +
-  `passwordLoginPageHtml(next)`（恒渲染）；POST → `handlePasswordLogin(deps, req, res)`；
-  其他 → 405 + `allow: GET, POST`。
-- exact `/auth/logout`：仅 POST（其他 405 + `allow: POST`）——逻辑与 M2 `logout` 逐字一致
-  （next 仅 query、revoke 幂等、`buildSetCookie(name, "", 0, cookieSecure)` 清 cookie、302、
-  `info("logout")`）。
-- exact `/auth/status`：仅 GET（其他 405 + `allow: GET`）——逻辑与 M2 `handleStatus` 逐字一致
-  （只认 cookie，Bearer 不参与）。
+- prefix `/auth` → always 404 `"not found"` + no-store (P16).
+- exact `/auth/login`: GET → `validateNext(query.get("next") ?? "/")` + 200 text/html +
+  `passwordLoginPageHtml(next)` (always renders); POST → `handlePasswordLogin(deps, req, res)`;
+  others → 405 + `allow: GET, POST`.
+- exact `/auth/logout`: POST-only (others 405 + `allow: POST`) — logic verbatim identical to M2 `logout`
+  (next query-only, revoke idempotent, `buildSetCookie(name, "", 0, cookieSecure)` clears the cookie, 302,
+  `info("logout")`).
+- exact `/auth/status`: GET-only (others 405 + `allow: GET`) — logic verbatim identical to M2 `handleStatus`
+  (cookie only, Bearer does not participate).
 
-`methodNotAllowed`/`queryOf`/catch-all handler 在本文件内实现（与 `auth-endpoints.ts` 的对应
-函数**内容一致但各自私有**——重复 ~35 行被接受：token 流已冻结、两流生命周期独立；若 M4 需要
-合并再动）。全部响应 no-store。
+`methodNotAllowed`/`queryOf`/the catch-all handler are implemented inside this file (**content-identical to the
+corresponding functions in `auth-endpoints.ts` but each is private** — ~35 duplicated lines accepted: the token
+flow is frozen and the two flows' lifecycles are independent; merge only if M4 needs it). All responses no-store.
 
-### 4.9 `src/cli.ts` —— dsh-auth 用户管理 CLI
+### 4.9 `src/cli.ts` — dsh-auth user management CLI
 
 ```ts
 #!/usr/bin/env node
 import { pathToFileURL } from "node:url";
-// users-file / password 模块 import 同 src 惯例（相对 .js 后缀）
+// users-file / password module imports follow the same src convention (relative `.js` suffix)
 
 export interface CliIo {
   out(line: string): void;
   err(line: string): void;
-  readLine(): Promise<string>; // stdin 一行，去尾部 \r\n；EOF → ""
+  readLine(): Promise<string>; // one stdin line, trailing \r\n stripped; EOF → ""
 }
 
-/** 返回进程退出码。所有参数/IO 经 argv/io 注入（可测，禁 console.*）。 */
+/** Return the process exit code. All arguments/IO go through argv/io injection (testable, console.* forbidden). */
 export async function main(argv: string[], io: CliIo): Promise<number>;
 
-// 文件底部入口（保持最后）：
+// Entry point at the file bottom (kept last):
 // if (import.meta.url === pathToFileURL(process.argv[1] ?? "").href) {
 //   void main(process.argv.slice(2), defaultIo).then((code) => { process.exitCode = code; });
 // }
 ```
 
-行为约定：
+Behavior contract:
 
-- 用法文本（冻结，两处 usage 共用一份常量）：
+- Usage text (frozen, one shared constant for both usage sites):
   ```
   Usage:
     dsh-auth user add <name> --password-stdin [--disabled] [--file <path>]
     dsh-auth user list [--file <path>]
     dsh-auth user disable <name> [--file <path>]
   ```
-- 参数解析：`--file` 后跟一个值（原样取用，不做路径展开）；`--disabled`、`--password-stdin`
-  为布尔 flag；不认识的 token / 非 `user` 子命令 / 未知子命令 → err(usage) + return 1。
-- `add`：name 必须匹配 `USERNAME_RE`（否则 err + 1）；`--password-stdin` 缺失 → err(usage) + 1；
-  `(await loadUsersFile(file)).snapshot` → 已存在同名 → err(`user <name> already exists`) + 1；
-  `readLine()` 为空 → err(`empty password`) + 1；`hashPassword(pw)` → 加入快照（`disabled` 按
-  flag，默认 false）→ `writeUsersFile` → out(`user <name> added`)。
-- `list`：`(await loadUsersFile(file)).snapshot` → 按用户名字典序（显式比较器）逐行 out(`<name>` /
-  `<name> (disabled)`)。文件缺失（`missing: true`）→ 无输出、exit 0。
-- `disable`：`(await loadUsersFile(file)).snapshot` → 不存在 → err(`user not found`) + 1；
-  置 `disabled: true` → `writeUsersFile` → out(`user <name> disabled`)（已禁用同输出，幂等）。
-- 所有 `loadUsersFile`/`writeUsersFile` 抛错（`UsersFileError` 或 IO）→ err(message) + 1。
-- `defaultIo`：`out = (l) => process.stdout.write(l + "\n")`、err 同 stderr、`readLine` 用
-  `node:readline` 对 `process.stdin` 取一行后 close。
+- Argument parsing: `--file` takes one value (used as-is, no path expansion); `--disabled`, `--password-stdin`
+  are boolean flags; unrecognized token / non-`user` subcommand / unknown subcommand → err(usage) + return 1.
+- `add`: name must match `USERNAME_RE` (otherwise err + 1); `--password-stdin` missing → err(usage) + 1;
+  `(await loadUsersFile(file)).snapshot` → same name already exists → err(`user <name> already exists`) + 1;
+  `readLine()` empty → err(`empty password`) + 1; `hashPassword(pw)` → add to snapshot (`disabled` per
+  flag, default false) → `writeUsersFile` → out(`user <name> added`).
+- `list`: `(await loadUsersFile(file)).snapshot` → in lexicographic order by username (explicit comparator),
+  one line each via out(`<name>` / `<name> (disabled)`). File missing (`missing: true`) → no output, exit 0.
+- `disable`: `(await loadUsersFile(file)).snapshot` → not exist → err(`user not found`) + 1;
+  set `disabled: true` → `writeUsersFile` → out(`user <name> disabled`) (same output when already disabled,
+  idempotent).
+- Any `loadUsersFile`/`writeUsersFile` throw (`UsersFileError` or IO) → err(message) + 1.
+- `defaultIo`: `out = (l) => process.stdout.write(l + "\n")`, err likewise to stderr, `readLine` uses
+  `node:readline` against `process.stdin`, reads one line then closes.
 
-### 4.10 `src/index.ts` —— 装配变更（P26；其余 M1/M2 逻辑不动）
+### 4.10 `src/index.ts` — assembly changes (P26; other M1/M2 logic unchanged)
 
-1. `AuthConfig` 增 `usersFile: string`（注释：`""` = 按 P6 解析默认路径；password 模式专用，
-   token 模式忽略）；`Config` 增 `usersFile: z.string().default("")`。`mode` 的 JSDoc 更新为
-   "token（M2）/ password（M3）"。
-2. **删除** apply 开头的 `mode === "password" → throw`（M2 的 L99–101）。
-3. `resolveToken` 仅 token 模式构造（password 模式不构造、不访问 credentials）：
+1. `AuthConfig` adds `usersFile: string` (comment: `""` = resolve default path per P6; password-mode only,
+   ignored in token mode); `Config` adds `usersFile: z.string().default("")`. `mode`'s JSDoc updated to
+   "token (M2) / password (M3)".
+2. **Remove** the `mode === "password" → throw` at the start of apply (M2's L99–101).
+3. `resolveToken` is only constructed in token mode (not constructed, not accessing credentials, in password mode):
    ```ts
    const resolveToken = config.mode === "token" ? makeTokenResolver(ctx, config, log) : undefined;
    ```
-4. password 分支专属常量（token 模式也计算、无害——`usersPath`/`limiter` 都被第 6 步三元表达式
-   引用，不算未使用变量；`makeTokenResolver` 惰性取服务，password 模式下从未被调用）：
+4. password-branch-specific constants (also computed in token mode, harmless — `usersPath`/`limiter` are both
+   referenced by step 6's ternary, so not unused variables; `makeTokenResolver` lazily fetches the service and is
+   never called in password mode):
    ```ts
    const usersPath = config.usersFile === "" ? defaultUsersFilePath() : config.usersFile;
    const limiter = new LoginRateLimiter();
    ```
-5. `auth` 一步成型（P26；闭包自引用在 decide 时才求值）：
+5. `auth` formed in one step (P26; the self-referential closure is evaluated only at `decide` time):
    ```ts
    const auth: AuthService = {
      sessions: undefined,
@@ -446,7 +468,8 @@ export async function main(argv: string[], io: CliIo): Promise<number>;
        config.mode === "password"
          ? new PasswordGate({ sessions: () => auth.sessions, cookieName: config.cookieName })
          : new TokenGate({
-             // token 模式下 makeTokenResolver 必返回函数；`??` 兜底仅类型对齐（不可达且 fail-closed）
+             // in token mode makeTokenResolver must return a function; the `??` fallback only aligns types
+             // (unreachable and fail-closed)
              resolveToken: resolveToken ?? (async () => undefined),
              sessions: () => auth.sessions,
              cookieName: config.cookieName,
@@ -454,8 +477,8 @@ export async function main(argv: string[], io: CliIo): Promise<number>;
    };
    ctx.provide("auth", auth);
    ```
-6. 端点注册按 mode 二选一（自检仍在端点注册**之后**；token 分支的 `validateToken` 闭包同样用
-   `resolveToken ?? (async () => undefined)` 兜底）：
+6. Endpoint registration chooses one of two by mode (self-check still runs **after** endpoint registration; the
+   token branch's `validateToken` closure likewise uses the `resolveToken ?? (async () => undefined)` fallback):
    ```ts
    ctx.effect(
      () =>
@@ -473,7 +496,7 @@ export async function main(argv: string[], io: CliIo): Promise<number>;
              logger: log,
            })
          : registerAuthEndpoints({
-             // M2 参数逐字保留：register/sessions/cookieName/cookieSecure/sessionTtl/logger 同上
+             // M2 params preserved verbatim: register/sessions/cookieName/cookieSecure/sessionTtl/logger as above
              validateToken: async (token) => {
                const stored = await (resolveToken ?? (async () => undefined))();
                return stored !== undefined && safeEqual(token, stored);
@@ -482,257 +505,276 @@ export async function main(argv: string[], io: CliIo): Promise<number>;
      "dsh-auth: auth endpoints",
    );
    ```
-7. storage 软接、`wrapServer`、自检：**零改动**（顺序保持：storage → wrap → endpoints → self-check）。
+7. storage soft-wiring, `wrapServer`, self-check: **zero changes** (order preserved: storage → wrap → endpoints →
+   self-check).
 
-### 4.11 `package.json` / 文档
+### 4.11 `package.json` / documentation
 
-- `dependencies` 增 `"yaml": "^2.9.0"`（排序按既有字母序）；顶层增
-  `"bin": { "dsh-auth": "lib/cli.js" }`。`files: ["lib"]` 已含 CLI 产物；`main`/`exports` 不动。
-- `README.md` 新增一节（消费者契约）：`mode: "password"` 配置、users 文件格式与权限（0600、
-  归 CLI 管）、CLI 用法、token → password 迁移说明、已知局限（限速内存态重启清零；禁用用户
-  不吊销已发会话；无 CSRF token 的残余风险；Bearer 会话 token 语义；XFF 不信任）。
-- `docs/development.md` 的 `## Structure` 树按 §4 新文件更新。
-- `AGENTS.md` 增两行指针：M3 规格 `docs/impl-m3.md` + 交接 `docs/handoff-m3.md`（后者由执行
-  session 收尾时写，见 DoD 6）。
+- `dependencies` adds `"yaml": "^2.9.0"` (ordered by the existing alphabetical order); the top level adds
+  `"bin": { "dsh-auth": "lib/cli.js" }`. `files: ["lib"]` already includes the CLI output; `main`/`exports`
+  unchanged.
+- `README.md` adds a section (consumer contract): `mode: "password"` configuration, users file format and
+  permissions (0600, managed by the CLI), CLI usage, token → password migration notes, known limitations
+  (rate limiting is in-memory and resets on restart; disabled users do not revoke already-issued sessions; residual
+  risk without a CSRF token; Bearer session token semantics; XFF is not trusted).
+- `docs/development.md`'s `## Structure` tree updated per the §4 new files.
+- `AGENTS.md` adds two-pointer lines: the M3 spec `docs/impl-m3.md` + the handoff `docs/handoff-m3.md` (the latter
+  written by the execution session when wrapping up; see DoD 6).
 
 ---
 
-## 5. 测试矩阵
+## 5. Test matrix
 
-M1/M2 测试**全保留且必须原样绿**（`auth-endpoints*.test.ts` 不因 P17 改动而变——validateNext
-行为不变）。`src/index.test.ts` 按 §4.10 适配。新增（全部显式 vitest import；大套件按 describe
-拆文件，每个 ≤250 行）：
+M1/M2 tests **all preserved and must stay green unchanged** (`auth-endpoints*.test.ts` does not change as a result
+of P17 — validateNext behavior is unchanged). `src/index.test.ts` adapts per §4.10. New tests (all explicit vitest
+imports; large suites split into files by describe, each ≤250 lines):
 
 **`src/password.test.ts`** —
 
-1. `hashPassword` 输出匹配 `/^scrypt\$65536\$8\$1\$[A-Za-z0-9_-]{22}\$[A-Za-z0-9_-]{43}$/`；
-   两次调用 salt 不同（串不等）。
-2. roundtrip：`verifyPassword(pw, await hashPassword(pw)) === true`。
-3. 错口令 → false；空串口令 hash/verify 正常（hash("") 可验证）。
-4. `verifyPassword` 坏输入全分支：非 6 段、前缀错、N/r/p 非数字、N > 2¹⁷、salt 段长度错、非法
-   base64url → 全部 false 且不抛。
-5. DUMMY_HASH 已知向量：`verifyPassword("dsh-auth-dummy-password-for-timing-uniformity", DUMMY_HASH) === true`；
-   其他口令 → false（DUMMY 口令字面量不是秘密，允许出现在断言）。
-6. 参数演进兼容：手工构造合法旧参数哈希（`scryptSync` 按 N=2¹⁴ 生成，拼成
-   `scrypt$16384$8$1$<salt>$<hash>`）→ 在模块常量 N=2¹⁶ 下 `verifyPassword` 仍成功（证明验证
-   走 **stored 自带参数**而非当前常量；注意 scrypt 的 N 参与派生，**改 N 段必须同时重派生**
-   才成立——原"替换 N 段"写法是错的，实施时已修正为上述构造法）。
+1. `hashPassword` output matches `/^scrypt\$65536\$8\$1\$[A-Za-z0-9_-]{22}\$[A-Za-z0-9_-]{43}$/`;
+   two calls produce different salts (strings unequal).
+2. roundtrip: `verifyPassword(pw, await hashPassword(pw)) === true`.
+3. wrong password → false; empty-string password hashes/verifies normally (`hash("")` is verifiable).
+4. `verifyPassword` all bad-input branches: not 6 segments, wrong prefix, N/r/p not numeric, N > 2¹⁷, wrong salt
+   segment length, invalid base64url → all false and no throw.
+5. DUMMY_HASH known vector: `verifyPassword("dsh-auth-dummy-password-for-timing-uniformity", DUMMY_HASH) === true`;
+   other passwords → false (the DUMMY password literal is not a secret, allowed in assertions).
+6. parameter-evolution compatibility: manually construct a valid old-parameter hash (`scryptSync` generated at
+   N=2¹⁴, assembled as `scrypt$16384$8$1$<salt>$<hash>`) → `verifyPassword` still succeeds under the module constant
+   N=2¹⁶ (proving verification uses the **parameters carried by stored** rather than the current constants; note
+   that scrypt's N participates in derivation, so **changing the N segment requires re-deriving at the same time**
+   for validity — the original "replace the N segment" approach was wrong and was corrected in implementation to the
+   construction method above).
 
-**`src/rate-limit.test.ts`**（注入 `now`）—
+**`src/rate-limit.test.ts`** (injected `now`) —
 
-1. 前 4 次失败 → check 恒 allowed。
-2. 第 5 次失败后 check → locked，`retryAfterSeconds === 30`。
-3. 第 6 次失败后 → 60；增长到 900 封顶（多打几次断言封顶）。
-4. 锁定期 check locked（不再 recordFailure）。
-5. 时钟越过 lockUntil → check allowed 且计数已清零（失败重新从 1 计）。
-6. `recordSuccess` 后 check allowed、计数清零。
-7. IP 桶与账号桶独立：同 IP 不同账号失败互不锁定对方；不同 IP 同一账号被账号桶锁定。
-8. `account: undefined`/`""` 只动 IP 桶。
-9. 衰减与修剪：注入 now——3 次失败后推进时钟 10 分钟 → check 清零且条目被删（后续 check 观察
-   不到计数）；条目数超 10000 删最早——上限是模块常量不导出，测试用 10001 个**互异 key** 各
-   `recordFailure` 一次（failures=1，不会被普通修剪删掉）灌满后调一次 `check`，断言 Map 大小
-   回落到 10000 且最早插入的 key 已被淘汰（各 ~几 ms，可行）。
+1. First 4 failures → check always allowed.
+2. After the 5th failure check → locked, `retryAfterSeconds === 30`.
+3. After the 6th failure → 60; grows to cap at 900 (call a few more times to assert the cap).
+4. During the lock period check is locked (no further `recordFailure`).
+5. Clock passes `lockUntil` → check allowed and counters cleared (failures restart from 1).
+6. After `recordSuccess` check allowed, counters cleared.
+7. IP bucket and account bucket are independent: different accounts failing on the same IP do not lock each other;
+   the same account on different IPs is locked by the account bucket.
+8. `account: undefined`/`""` only touches the IP bucket.
+9. decay and pruning: injected now — after 3 failures advance the clock 10 minutes → check clears and the entry is
+   deleted (the count is not observable on subsequent checks); when the entry count exceeds 10000 the earliest is
+   deleted — the cap is a module constant not exported, so use 10001 **distinct keys**, each `recordFailure` once
+   (failures=1, so ordinary pruning will not delete them), then call `check` once and assert the Map size falls
+   back to 10000 and the earliest-inserted key has been evicted (each a few ms, feasible).
 
-**`src/users-file.test.ts`**（`mkdtemp` 临时目录；`it.skipIf(process.platform === "win32")` 的
-用例用 vitest 条件跳过）—
+**`src/users-file.test.ts`** (`mkdtemp` temp directory; cases with `it.skipIf(process.platform === "win32")` use
+vitest conditional skip) —
 
-1. `defaultUsersFilePath`：`vi.stubEnv("DSH_HOME", tmp)` → 拼出 `<tmp>/auth/users.yaml`；
-   无 env → `path.join(os.homedir(), ".dsh", "auth", "users.yaml")`（断言前缀 homedir；测试后
-   `vi.unstubAllEnvs()`）。
-2. load：合法文件（两个用户，一个带 totpSecret/disabled）→ Map 内容正确、disabled 缺省 false。
-3. 文件不存在 → `{ snapshot: 空 Map, missing: true }`（不抛）；存在且合法 → `missing: false`。
-4. 坏 YAML（语法）→ `UsersFileError`；重复键 YAML → `UsersFileError`。
-5. schema 错：version 非 1、未知顶层键、未知用户字段、缺失 passwordHash、非法用户名、totpSecret
-   非字符串 → 全部 `UsersFileError`。
-6. 权限过宽（`writeFileSync` 后 `chmodSync(0o644)`）→ `UsersFileError`（POSIX only）。
-7. write：快照 → 文件内容精确（yaml 结构、用户名字典序、`disabled: true` 显式）；mode 0600
-   （`statSync` 断言，POSIX only）；`.tmp` 残留不存在；目录不存在时自动创建。
+1. `defaultUsersFilePath`: `vi.stubEnv("DSH_HOME", tmp)` → assembles `<tmp>/auth/users.yaml`;
+   no env → `path.join(os.homedir(), ".dsh", "auth", "users.yaml")` (assert homedir prefix; afterwards
+   `vi.unstubAllEnvs()`).
+2. load: a valid file (two users, one with totpSecret/disabled) → Map contents correct, `disabled` defaults to
+   false.
+3. File absent → `{ snapshot: empty Map, missing: true }` (no throw); present and valid → `missing: false`.
+4. Bad YAML (syntax) → `UsersFileError`; duplicate-key YAML → `UsersFileError`.
+5. schema errors: version not 1, unknown top-level key, unknown user field, missing passwordHash, invalid
+   username, totpSecret not a string → all `UsersFileError`.
+6. overly permissive permissions (`writeFileSync` then `chmodSync(0o644)`) → `UsersFileError` (POSIX only).
+7. write: snapshot → file contents exact (yaml structure, lexicographic usernames, `disabled: true` explicit);
+   mode 0600 (`statSync` assert, POSIX only); no `.tmp` residual; directory auto-created when absent.
 
-**`src/password-gate.test.ts`**（fake req headers + fake sessions（MemTable 思路复用））—
+**`src/password-gate.test.ts`** (fake req headers + fake sessions (reusing the MemTable idea)) —
 
-1. 白名单：`/auth`、`/auth/login`、`/auth/whatever` → allow（无凭证）。
-2. cookie 通道：有效会话 → allow；未知/过期/revoked token → deny；cookie 头缺失 → deny。
-3. Bearer 通道：`Authorization: Bearer <会话 token>` → allow；未知 token → deny；`bearer` 小写
-   前缀可接受；带前缀格式错误 → deny。
-4. `sessions: () => undefined`：cookie 与 bearer 都跳过 → deny（白名单除外）。
-5. 无凭证 → deny。返回值为同步 `"allow" | "deny"`（非 Promise）。
+1. whitelist: `/auth`, `/auth/login`, `/auth/whatever` → allow (no credentials).
+2. cookie channel: valid session → allow; unknown/expired/revoked token → deny; cookie header absent → deny.
+3. Bearer channel: `Authorization: Bearer <session token>` → allow; unknown token → deny; lowercase `bearer`
+   prefix acceptable; malformed prefix format → deny.
+4. `sessions: () => undefined`: both cookie and bearer skipped → deny (except the whitelist).
+5. no credentials → deny. Return value is the synchronous `"allow" | "deny"` (not a Promise).
 
-**`src/password-endpoints.test.ts`**（fake register/limiter/loadUsers/verify/sessions；按行数拆三
-文件：`password-endpoints.test.ts` 注册形状/GET login/logout/status，
-`password-endpoints.login.test.ts` POST login，`password-endpoints.methods.test.ts`
-405/兜底/415/413/页面 escape——矩阵合并描述）—
+**`src/password-endpoints.test.ts`** (fake register/limiter/loadUsers/verify/sessions; split into three files by
+line count: `password-endpoints.test.ts` for registration shape/GET login/logout/status,
+`password-endpoints.login.test.ts` for POST login, `password-endpoints.methods.test.ts` for
+405/fallback/415/413/page escaping — the matrix below is the merged description) —
 
-1. 注册形状：4 条——prefix `/auth`、exact `/auth/login`、`/auth/logout`、`/auth/status`。
-2. GET login：200 + HTML 含 `<form`、`name="username"`、`name="password"`；hidden next escape
-   （`next="/x?a=1&b=2"` → `&amp;`）；已有有效会话也恒 200 渲染（M20 一致）。
-3. POST login 成功：fake verify true → 302 location=next + set-cookie 精确串（secure=true/false
-   两态）+ `sessions().create` 被调（subject = username、ttl = sessionTtl*1000）+
-   `limiter.recordSuccess` 被调 + `info("session issued")`。
-4. POST login 失败：verify false → 401 `"invalid credentials"` + `info("login rejected")` +
-   `recordFailure` 被调、无会话创建；未知用户（loadUsers 不含该名）→ verify 收到 **DUMMY_HASH**
-   - 401；禁用用户 → verify 收到该用户真哈希 + 401（P9：三态统一）。
-5. POST login 429：limiter 预置 locked → 429 + `retry-after` 数值 + `info("rate limit exceeded")`；
-   **verify 未被调**（锁定期不验证）。
-6. POST login 503：fake loadUsers reject → 503 `"user store unavailable"` + error 日志 + 不计
-   失败；`sessions()` undefined → 503 `"session store unavailable"`。
-   6b. POST login 文件缺失：fake loadUsers 返回 `{ snapshot: 空, missing: true }` → 401
-   `"invalid credentials"`（空用户集）+ **首次** `warn("users file not found: ...")` 一次；
-   第二次登录不再重复 warn（模块级 flag）。
-7. POST login next 校验：`//evil.com` → `/`；`/ok/path` → 原样；`/auth/login`、`/auth/x` → `/`
-   （M20 回环防护沿用）。
-8. POST login 空 username：只动 IP 桶（fake limiter 断言 account 参数 undefined）；成功路径
-   username 非空 → account 参数 = username。
-9. POST logout：revoke 被调 + set-cookie 含 `Max-Age=0` + 302；next 仅 query；无 body/无
-   content-type 可用；cookie 缺失也 302 幂等（M22 复刻）。
-10. GET status：有效 cookie → `{"authenticated":true}`；无 → false；带 `Authorization: Bearer`
-    头不影响（只认 cookie，M5）。
-11. method 分发：`DELETE /auth/login` → 405 + `allow: GET, POST`；`GET /auth/logout` → 405；
-    `POST /auth/status` → 405。
-12. prefix 兜底：`/auth/whatever` → 404 + no-store。
-13. 415/413：非 urlencoded → 415；超 16 KiB → 413 + `connection: close` + 不调 `req.destroy`
-    （M19 复刻）。
-14. `passwordLoginPageHtml`：直接断言 HTML 含两字段与 escape（本文件或 login-page 相关文件内）。
+1. registration shape: 4 — prefix `/auth`, exact `/auth/login`, `/auth/logout`, `/auth/status`.
+2. GET login: 200 + HTML containing `<form`, `name="username"`, `name="password"`; hidden next escaped
+   (`next="/x?a=1&b=2"` → `&amp;`); with an existing valid session it still always renders 200 (consistent with
+   M20).
+3. POST login success: fake verify true → 302 location=next + exact set-cookie string (both secure=true/false
+   states) + `sessions().create` called (subject = username, ttl = sessionTtl*1000) +
+   `limiter.recordSuccess` called + `info("session issued")`.
+4. POST login failure: verify false → 401 `"invalid credentials"` + `info("login rejected")` +
+   `recordFailure` called, no session created; unknown user (loadUsers does not contain the name) → verify receives
+   **DUMMY_HASH** → 401; disabled user → verify receives that user's real hash + 401 (P9: three states unified).
+5. POST login 429: limiter preset locked → 429 + numeric `retry-after` + `info("rate limit exceeded")`;
+   **verify not called** (no verification during the lock period).
+6. POST login 503: fake loadUsers rejects → 503 `"user store unavailable"` + error log + no failure counted;
+   `sessions()` undefined → 503 `"session store unavailable"`.
+   6b. POST login file missing: fake loadUsers returns `{ snapshot: empty, missing: true }` → 401
+   `"invalid credentials"` (empty user set) + `warn("users file not found: ...")` **once, on the first time**;
+   the second login does not repeat the warn (module-level flag).
+7. POST login next validation: `//evil.com` → `/`; `/ok/path` → as-is; `/auth/login`, `/auth/x` → `/`
+   (M20 loopback protection carried over).
+8. POST login empty username: only the IP bucket is touched (fake limiter asserts the account argument is
+   undefined); on the success path with a non-empty username → the account argument = username.
+9. POST logout: revoke called + set-cookie contains `Max-Age=0` + 302; next is query-only; no-body/no
+   content-type usable; 302 idempotent even without a cookie (replicating M22).
+10. GET status: valid cookie → `{"authenticated":true}`; none → false; an `Authorization: Bearer`
+    header has no effect (cookie only, M5).
+11. method dispatch: `DELETE /auth/login` → 405 + `allow: GET, POST`; `GET /auth/logout` → 405;
+    `POST /auth/status` → 405.
+12. prefix fallback: `/auth/whatever` → 404 + no-store.
+13. 415/413: not urlencoded → 415; over 16 KiB → 413 + `connection: close` + `req.destroy` not called
+    (replicating M19).
+14. `passwordLoginPageHtml`: directly assert the HTML contains both fields and escaping (in this file or in the
+    login-page-related file).
 
-**`src/cli.test.ts`**（fake `CliIo`：`out/err` 收集到数组、`readLine` 返回预置行）—
+**`src/cli.test.ts`** (fake `CliIo`: `out/err` collected into arrays, `readLine` returns preset lines) —
 
-1. `add` 全流程：mkdtemp 文件路径 + `--password-stdin` → exit 0、out 含 `user alice added`、
-   文件已建且 mode 0600（POSIX only）、再 `loadUsersFile` 读回含 alice；用 `verifyPassword` 验证
-   文件里的哈希能验证该口令（真实 scrypt 一次）。
-2. `add` 失败分支：缺 `--password-stdin` → exit 1 + usage；name 非法（含空格/开头数字）→ exit 1；
-   同名已存在 → exit 1 + `already exists`；stdin 空行 → exit 1。
-3. `add --disabled` → 读回 `disabled: true`。
-4. `list`：预置两用户（一禁用）→ 输出两行、字典序、`(disabled)` 标记；空文件 → 无输出 exit 0。
-5. `disable`：→ exit 0 + `user alice disabled` + 读回 disabled；不存在 → exit 1 + `not found`；
-   再次 disable → 幂等 exit 0。
-6. 未知子命令/未知 flag → exit 1 + usage 到 err。
-7. `--file` 指向不存在目录 → 自动创建（writeUsersFile 语义）。
+1. `add` full flow: mkdtemp file path + `--password-stdin` → exit 0, out contains `user alice added`,
+   the file exists with mode 0600 (POSIX only), then re-reading via `loadUsersFile` contains alice; use
+   `verifyPassword` to confirm the hash in the file verifies that password (one real scrypt).
+2. `add` failure branches: missing `--password-stdin` → exit 1 + usage; invalid name (with a space / starts with a
+   digit) → exit 1; same name already exists → exit 1 + `already exists`; empty stdin line → exit 1.
+3. `add --disabled` → reading back yields `disabled: true`.
+4. `list`: preset two users (one disabled) → two output lines, lexicographic, `(disabled)` marker; empty file →
+   no output, exit 0.
+5. `disable`: → exit 0 + `user alice disabled` + reading back shows disabled; not exist → exit 1 + `not found`;
+   disabling again → idempotent exit 0.
+6. unknown subcommand/unknown flag → exit 1 + usage to err.
+7. `--file` pointing at a nonexistent directory → auto-created (writeUsersFile semantics).
 
-**`src/index.test.ts` 适配**（既有用例全保留，新增/修改）—
+**`src/index.test.ts` adaptation** (all existing cases preserved, new additions/modifications) —
 
-1. `mode: "password"` **不再抛错**（M2 的抛错用例删除）；gate 为 `PasswordGate` 实例。
-2. `mode: "token"`（默认）gate 仍为 `TokenGate`；fake ctx 记录 `get("credentials")` 被访问。
-3. password 模式：fake ctx 断言 `get("credentials")` **未被访问**；端点注册走 password 版
-   （fake register 记录 4 条路由，与 token 版同形）。
-4. `usersFile` 默认解析：`vi.stubEnv("DSH_HOME", tmp)` 下挂载 password 模式 + `vi.mock("./password-endpoints.js")`
-   捕获 `registerPasswordEndpoints` 收到的 deps → 断言 `deps.usersPath === path.join(tmp, "auth", "users.yaml")`；
-   显式 `usersFile: "/x.yaml"` → `deps.usersPath === "/x.yaml"`。测试后 `vi.unstubAllEnvs()`。
-5. Config 默认值：`{}` → 含 `usersFile: ""`。
-6. 既有注销/自检/双缺失用例保持绿（token 分支）。
+1. `mode: "password"` **no longer throws** (delete M2's throw test case); the gate is a `PasswordGate` instance.
+2. `mode: "token"` (default) gate is still `TokenGate`; the fake ctx records that `get("credentials")` was accessed.
+3. password mode: the fake ctx asserts `get("credentials")` was **not accessed**; endpoint registration goes through
+   the password version (fake register records 4 routes, same shape as the token version).
+4. `usersFile` default resolution: under `vi.stubEnv("DSH_HOME", tmp)`, mount password mode with `vi.mock("./password-endpoints.js")`
+   capturing the deps `registerPasswordEndpoints` receives → assert `deps.usersPath === path.join(tmp, "auth", "users.yaml")`;
+   explicit `usersFile: "/x.yaml"` → `deps.usersPath === "/x.yaml"`. Afterwards `vi.unstubAllEnvs()`.
+5. Config defaults: `{}` → contains `usersFile: ""`.
+6. existing logout/self-check/both-missing cases stay green (token branch).
 
-**`src/integration.password.test.ts`**（真实入口路径）— 真实 cordis + **真实 storage 栈**
-（Storage → storage-json → storage-domain，挂载顺序同 `integration.auth.test.ts`）+ 真实
-WebServer + 真实 users 文件（`mkdtemp` root；`beforeAll` 用 `hashPassword` + `writeUsersFile`
-预置 `admin`（口令 `<test-password>`）与 `disableduser`（`disabled: true`））+ 本插件
-`config { mode: "password", cookieSecure: false, usersFile: <tmp>/users.yaml }`：
+**`src/integration.password.test.ts`** (real entry path) — real cordis + **real storage stack**
+(Storage → storage-json → storage-domain, mount order same as `integration.auth.test.ts`) + real
+WebServer + real users file (`mkdtemp` root; `beforeAll` uses `hashPassword` + `writeUsersFile`
+to preset `admin` (password `<test-password>`) and `disableduser` (`disabled: true`)) + this plugin
+`config { mode: "password", cookieSecure: false, usersFile: <tmp>/users.yaml }`:
 
-1. 全流程：`GET /auth/login` → 200 含 `name="username"`；错口令 → 401；对 → 302 + set-cookie +
-   location；带 cookie `GET /__probe` → 200；无 cookie → 302（HTML accept）/ 401（JSON accept）；
-   `Authorization: Bearer <cookie 里的会话 token>` → 200；Bearer 错 → 401；`POST /auth/logout?next=/`
-   带 cookie → 302 + Max-Age=0；原 cookie 再访问 → 401。
-2. subject 审计：登录成功后 `ctx.get("auth")!.sessions!.getByToken(<cookie token>)!.subject === "admin"`。
-3. 禁用/未知用户：disableduser → 401；`ghost` → 401（响应体一致 `invalid credentials`）。
-4. 文件不可用：改写 users.yaml 为坏 YAML → 登录 503；恢复 → 401 正常。文件缺失（指向不存在的
-   路径，独立实例）→ 登录 401（空用户集）。
-5. WS 通道：带会话 cookie 的 upgrade → 101；`Authorization: Bearer <会话 token>` 的 upgrade →
-   101；无凭证 → 401 拒握手（复用 M1 `requestUpgradeStatus` 模式 + 变体头）。
-6. 429 限速：**独立 describe + 新 ctx/端口**（P25——不污染共享实例的 limiter）：连错 5 次 →
-   第 6 次 429 + `retry-after` 头；随后正确口令也 429（锁定中）。
-7. token 模式回归由既有 `integration.auth.test.ts` 承担（不动、必须绿）。
+1. full flow: `GET /auth/login` → 200 containing `name="username"`; wrong password → 401; correct → 302 +
+   set-cookie + location; with cookie `GET /__probe` → 200; without cookie → 302 (HTML accept) / 401 (JSON
+   accept); `Authorization: Bearer <session token from the cookie>` → 200; wrong Bearer → 401;
+   `POST /auth/logout?next=/` with cookie → 302 + Max-Age=0; the original cookie then → 401.
+2. subject audit: after a successful login, `ctx.get("auth")!.sessions!.getByToken(<cookie token>)!.subject === "admin"`.
+3. disabled/unknown users: disableduser → 401; `ghost` → 401 (identical `invalid credentials` response body).
+4. file unusable: rewrite users.yaml as bad YAML → login 503; restore → normal 401. File missing (pointing at a
+   nonexistent path, standalone instance) → login 401 (empty user set).
+5. WS channel: upgrade with a session cookie → 101; upgrade with `Authorization: Bearer <session token>` →
+   101; no credentials → 401 rejects the handshake (reusing the M1 `requestUpgradeStatus` pattern + header
+   variants).
+6. 429 rate limiting: **separate describe + new ctx/port** (P25 — do not pollute the shared instance's limiter):
+   5 consecutive failures → the 6th is 429 + `retry-after` header; then even the correct password is 429 (locked).
+7. token-mode regression is covered by the existing `integration.auth.test.ts` (unchanged, must stay green).
 
 ---
 
-## 6. 实施顺序（每步保持 `npm run verify` 绿）
+## 6. Implementation order (keep `npm run verify` green at every step)
 
-1. `package.json`（yaml + bin）+ `npm install --registry=https://registry.npmjs.org/`。
-2. `src/password.ts` + `src/password.test.ts`。
-3. `src/rate-limit.ts` + `src/rate-limit.test.ts`。
-4. `src/users-file.ts` + `src/users-file.test.ts`。
-5. `src/auth-common.ts`（提取 validateNext）+ `auth-endpoints.ts` 改 import——**立即跑
+1. `package.json` (yaml + bin) + `npm install --registry=https://registry.npmjs.org/`.
+2. `src/password.ts` + `src/password.test.ts`.
+3. `src/rate-limit.ts` + `src/rate-limit.test.ts`.
+4. `src/users-file.ts` + `src/users-file.test.ts`.
+5. `src/auth-common.ts` (extract validateNext) + change `auth-endpoints.ts` to import — **immediately run
    `npm run test -- src/auth-endpoints.test.ts src/auth-endpoints.login.test.ts src/auth-endpoints.methods.test.ts`
-   证明 M2 行为未变**。
-6. `src/password-gate.ts` + `src/password-gate.test.ts`。
-7. `src/login-page.ts` 增量（`passwordLoginPageHtml`，随第 8/9 步测试覆盖）。
-8. `src/password-login.ts`（行数拆分件，测试经第 9 步）。
-9. `src/password-endpoints.ts` + 三个测试文件（`password-endpoints.test.ts` /
-   `password-endpoints.login.test.ts` / `password-endpoints.methods.test.ts`）。
-10. `src/cli.ts` + `src/cli.test.ts`。
-11. `src/index.ts` 装配 + `src/index.test.ts` 适配。
-12. `src/integration.password.test.ts`。
-13. 文档：`docs/development.md` Structure 树、`README.md`（密码模式/CLI/users 文件契约）、
-    `AGENTS.md`（M3 指针）。
-14. `npm run build` + `lib/` 与 `src/` 同批；`git diff --exit-code -- lib` 通过。
-15. 服务器端到端冒烟（DoD 4）。
-16. 收尾写 `docs/handoff-m3.md`（DoD 6）。
+   to prove M2 behavior is unchanged**.
+6. `src/password-gate.ts` + `src/password-gate.test.ts`.
+7. `src/login-page.ts` increment (`passwordLoginPageHtml`, covered by tests in steps 8/9).
+8. `src/password-login.ts` (line-count split piece, tested via step 9).
+9. `src/password-endpoints.ts` + three test files (`password-endpoints.test.ts` /
+   `password-endpoints.login.test.ts` / `password-endpoints.methods.test.ts`).
+10. `src/cli.ts` + `src/cli.test.ts`.
+11. `src/index.ts` assembly + `src/index.test.ts` adaptation.
+12. `src/integration.password.test.ts`.
+13. Documentation: `docs/development.md` Structure tree, `README.md` (password mode/CLI/users file contract),
+    `AGENTS.md` (M3 pointers).
+14. `npm run build` + `lib/` in the same batch as `src/`; `git diff --exit-code -- lib` passes.
+15. Server end-to-end smoke test (DoD 4).
+16. Wrap up by writing `docs/handoff-m3.md` (DoD 6).
 
 ---
 
 ## 7. Definition of Done
 
-1. `npm run verify` 全绿（format/lint/type-check/coverage ≥80%/lock:check）。
-2. `npm run build` + `lib/` 与 `src/` 同批；`git diff --exit-code -- lib` 通过。
-3. `npm run test -- src/integration.password.test.ts src/integration.auth.test.ts src/integration.guard.test.ts src/integration.session.test.ts` 单独跑绿（token 模式回归 + password 真实路径）。
-4. **服务器端到端冒烟**（环境事实见 handoff §3；**本机 loopback 不可达，一律在服务器上验证**）：
-   1. 同步：`rsync -az --exclude node_modules --exclude .git /Users/randal/source/dsh-auth/ ubuntu:/tmp/dsh-auth-test/`
-      → 服务器 `cd /tmp/dsh-auth-test && npm install --registry=https://registry.npmjs.org/ && npm run build`。
-   2. 建用户（真实 CLI 路径）：
+1. `npm run verify` fully green (format/lint/type-check/coverage ≥80%/lock:check).
+2. `npm run build` + `lib/` in the same batch as `src/`; `git diff --exit-code -- lib` passes.
+3. `npm run test -- src/integration.password.test.ts src/integration.auth.test.ts src/integration.guard.test.ts src/integration.session.test.ts` passes when run alone (token-mode regression + password real path).
+4. **Server end-to-end smoke test** (environment facts see handoff §3; **this machine's loopback is unreachable,
+   always verify on the server**):
+   1. sync: `rsync -az --exclude node_modules --exclude .git /Users/randal/source/dsh-auth/ ubuntu:/tmp/dsh-auth-test/`
+      → on the server `cd /tmp/dsh-auth-test && npm install --registry=https://registry.npmjs.org/ && npm run build`.
+   2. create a user (real CLI path):
       ```bash
       ssh ubuntu 'printf "%s\n" "<test-password>" | node /tmp/dsh-auth-test/lib/cli.js user add admin --password-stdin --file ~/dsh-smoke/auth/users.yaml'
       ssh ubuntu 'node /tmp/dsh-auth-test/lib/cli.js user list --file ~/dsh-smoke/auth/users.yaml'
-      ssh ubuntu 'stat -c "%a" ~/dsh-smoke/auth/users.yaml'   # 期望 600
+      ssh ubuntu 'stat -c "%a" ~/dsh-smoke/auth/users.yaml'   # expect 600
       ```
-   3. overlay `~/dsh-smoke/cordis.patch.yml`：`dsh-auth` 行 config 改为
-      `{ mode: "password", cookieSecure: false }`（M1 探针行确认已删——handoff §5.3）；重启实例
-      （`pkill -f "[d]sh --profile web --port 3081"` 与启动**分两个 ssh 调用**，handoff §6 教训；
-      `nohup ... > ~/dsh-smoke/boot.log 2>&1 < /dev/null &`，等 ~25s）。
-   4. 验证序列（**先跑正确口令全流程，429 序列放最后**——30s 锁只影响登录端点）：
-      - `curl -s http://127.0.0.1:3081/auth/login | grep -o 'name="username"'` → 命中；状态 200；
-      - `curl -s -o /dev/null -w "%{http_code}\n" -d "username=admin&password=wrong" http://127.0.0.1:3081/auth/login` → 401；
-      - `curl -s -i -d "username=admin&password=<test-password>" -c jar http://127.0.0.1:3081/auth/login | head -3` → 302 + `set-cookie`；
-      - `curl -s -o /dev/null -w "%{http_code}\n" -b jar http://127.0.0.1:3081/__auth_probe` → 200；
-        无 cookie：`-H "Accept: application/json"` → 401、`-H "Accept: text/html"` → 302；
-      - Bearer 会话 token：`TOK=$(awk '$6=="dsh_auth" {print $7}' jar)` →
-        `curl -s -o /dev/null -w "%{http_code}\n" -H "Authorization: Bearer $TOK" http://127.0.0.1:3081/__auth_probe` → 200；改错 token → 401；
-      - `curl -s http://127.0.0.1:3081/auth/status -b jar` → `{"authenticated":true}`；
-      - WS：无 cookie upgrade → 首行 `HTTP/1.1 401`；`-b jar` → `HTTP/1.1 101`（handoff §5.4 的
-        curl 命令 + `-b jar` / `-H "Authorization: Bearer $TOK"` 变体）；
+   3. overlay `~/dsh-smoke/cordis.patch.yml`: change the `dsh-auth` line's config to
+      `{ mode: "password", cookieSecure: false }` (confirm the M1 probe line is gone — handoff §5.3); restart the
+      instance (`pkill -f "[d]sh --profile web --port 3081"` and startup are **two separate ssh calls**, handoff
+      §6 lesson; `nohup ... > ~/dsh-smoke/boot.log 2>&1 < /dev/null &`, wait ~25s).
+   4. verification sequence (**run the correct-password full flow first, the 429 sequence last** — the 30s lock
+      only affects the login endpoint):
+      - `curl -s http://127.0.0.1:3081/auth/login | grep -o 'name="username"'` → hit; status 200;
+      - `curl -s -o /dev/null -w "%{http_code}\n" -d "username=admin&password=wrong" http://127.0.0.1:3081/auth/login` → 401;
+      - `curl -s -i -d "username=admin&password=<test-password>" -c jar http://127.0.0.1:3081/auth/login | head -3` → 302 + `set-cookie`;
+      - `curl -s -o /dev/null -w "%{http_code}\n" -b jar http://127.0.0.1:3081/__auth_probe` → 200;
+        without cookie: `-H "Accept: application/json"` → 401, `-H "Accept: text/html"` → 302;
+      - Bearer session token: `TOK=$(awk '$6=="dsh_auth" {print $7}' jar)` →
+        `curl -s -o /dev/null -w "%{http_code}\n" -H "Authorization: Bearer $TOK" http://127.0.0.1:3081/__auth_probe` → 200; a wrong token → 401;
+      - `curl -s http://127.0.0.1:3081/auth/status -b jar` → `{"authenticated":true}`;
+      - WS: upgrade without a cookie → first line `HTTP/1.1 401`; `-b jar` → `HTTP/1.1 101` (the
+        curl command from handoff §5.4 + the `-b jar` / `-H "Authorization: Bearer $TOK"` variants);
       - `curl -s -i -X POST "http://127.0.0.1:3081/auth/logout?next=/" -b jar | head -3` → 302 +
-        `Max-Age=0`；原 cookie 再 `GET /__auth_probe` → 401；
-      - `curl -s -o /dev/null -w "%{http_code}\n" http://127.0.0.1:3081/auth/whatever` → 404；
-      - 最后：错口令连发 6 次（`for i in 1 2 3 4 5 6; do curl -s -o /dev/null -w "%{http_code}\n" -d "username=admin&password=wrong" http://127.0.0.1:3081/auth/login; done`）
-        → 前 5 次 401、第 6 次 429；`curl -s -i -d "username=admin&password=<test-password>" http://127.0.0.1:3081/auth/login | head -5` → 429 + `retry-after` 头。
-   5. 收尾：杀掉实例或留用（报告状态）；`boot.log` 无 `password flow requires M3` 类报错。
-5. 报告：改动文件、P1–P26 落点、覆盖率数字、与本文档的偏差（应为零）。
-6. **写 `docs/handoff-m3.md`**（为 M4 交接）：环境事实增量（如 scrypt 实测耗时、CLI 在服务器上的
-   实际路径）、M3 冒烟真实结果、M3 踩坑清单、M4（TOTP）起点提示。已获用户指令才 commit/push。
+        `Max-Age=0`; the original cookie then `GET /__auth_probe` → 401;
+      - `curl -s -o /dev/null -w "%{http_code}\n" http://127.0.0.1:3081/auth/whatever` → 404;
+      - last: send the wrong password 6 times (`for i in 1 2 3 4 5 6; do curl -s -o /dev/null -w "%{http_code}\n" -d "username=admin&password=wrong" http://127.0.0.1:3081/auth/login; done`)
+        → first 5 are 401, the 6th is 429; `curl -s -i -d "username=admin&password=<test-password>" http://127.0.0.1:3081/auth/login | head -5` → 429 + `retry-after` header.
+   5. wrap up: kill or keep the instance (report status); `boot.log` has no `password flow requires M3`-style error.
+5. Report: changed files, P1–P26 landing points, coverage numbers, deviations from this document (should be zero).
+6. **Write `docs/handoff-m3.md`** (for the M4 handoff): environment-fact increments (e.g. measured scrypt time,
+   the CLI's actual path on the server), M3 smoke-test real results, an M3 pitfalls list, M4 (TOTP) starting-point
+   hints. Commit/push only when instructed by the user.
 
 ---
 
-## 8. 禁区清单
+## 8. Forbidden-zone checklist
 
-- **不探索 harness 内部**（同 M1/M2）；users 文件、scrypt、yaml 全部只经 §3 的事实。
-- **依赖只加 `yaml`**：scrypt/CLI 参数解析/readline 全内建；devDependencies 不动；不动
-  `dsh-credentials-local` 等任何 harness 包。
-- **不动 token 模式行为**：`token-gate.ts`/`cookie.ts`/`form-body.ts`/`guard.ts`/`gate.ts`/
-  `session-store.ts`/`self-check.ts` 零改动；`auth-endpoints.ts` 仅 P17 一处 import 机械改动；
-  `integration.auth.test.ts` 必须原样绿。
-- **不弱化安全参数**：scrypt N/r/p/maxmem 冻结（P1）；测试不得换弱参数（P25）；限速常量不配置化
-  （P22）。
-- **不落敏感值**：口令/用户名（登录日志）/哈希/会话 token 永不进日志与测试快照（P23）；DUMMY
-  常量例外（非秘密）。
-- **不吞认证失败**：未知用户/错口令/禁用统一 401；文件不可用 503；凭证/文件错误不静默放行。
-- **不改门禁**：eslint/tsconfig/vitest/coverage 阈值不动；不加 eslint-disable（除文件内既有允许项）。
-- **分支纪律**：`development`；未获指令不 commit/push；`lib/` 与 `src/` 同批。
-- M4（TOTP 两段式、`revokeBySubject`、CSRF token、限速持久化）**不做**——需要时只写
-  `TODO(auth-m4):` 注释（带稳定 tag）。
+- **Do not explore the harness internals** (same as M1/M2); users file, scrypt, yaml all go only through the facts
+  in §3.
+- **Only add `yaml` as a dependency**: scrypt/CLI argument parsing/readline are all built-in; devDependencies
+  unchanged; do not touch any harness package such as `dsh-credentials-local`.
+- **Do not change token-mode behavior**: `token-gate.ts`/`cookie.ts`/`form-body.ts`/`guard.ts`/`gate.ts`/
+  `session-store.ts`/`self-check.ts` zero changes; `auth-endpoints.ts` only the one mechanical P17 import change;
+  `integration.auth.test.ts` must stay green unchanged.
+- **Do not weaken security parameters**: scrypt N/r/p/maxmem frozen (P1); tests must not swap in weak parameters
+  (P25); rate-limit constants not configurable (P22).
+- **Do not log sensitive values**: passwords/usernames (login logs)/hashes/session tokens never enter logs and
+  test snapshots (P23); DUMMY constants are the exception (not secret).
+- **Do not swallow auth failures**: unknown user/wrong password/disabled all uniformly 401; file unusable 503;
+  credential/file errors are not silently passed through.
+- **Do not change the gates**: eslint/tsconfig/vitest/coverage thresholds unchanged; no `eslint-disable` (except
+  allowed items already present in a file).
+- **Branch discipline**: `development`; no commit/push without instruction; `lib/` in the same batch as `src/`.
+- M4 (TOTP two-step, `revokeBySubject`, CSRF token, rate-limit persistence) **is not done** — when needed, only
+  write a `TODO(auth-m4):` comment (with a stable tag).
 
 ---
 
-## 9. 明确不做（M3 范围外）
+## 9. Explicitly not done (outside M3 scope)
 
-- TOTP 两段式登录、`totpSecret` 的使用、防重放（M4）。
-- 禁用用户即时吊销已发会话（P15 局限，M4 评估 `revokeBySubject`）。
-- token + password 双模式并存（mode 二选一，P11）。
-- 登录限速持久化/跨进程（内存态，P10）。
-- CSRF token（P21 评估结论：M3 不加，M4 再评估）。
-- 登录页美化/国际化、client 半边登出按钮（GUI 组件）。
-- 部署侧交付物：正式生产 `cordis.patch.yml`、部署验收清单（M3 冒烟通过后单独做，handoff §6）。
+- TOTP two-step login, using `totpSecret`, replay protection (M4).
+- Immediately revoking already-issued sessions of disabled users (P15 limitation, evaluate `revokeBySubject` in M4).
+- token + password dual-mode coexistence (mode is one of two, P11).
+- Rate-limit persistence/across processes (in-memory, P10).
+- CSRF token (P21 evaluation conclusion: not in M3, re-evaluate in M4).
+- Login page beautification/internationalization, the client-side sign-out button (GUI components).
+- Deploy-side deliverables: a production `cordis.patch.yml`, the deployment acceptance checklist (done separately
+  after the M3 smoke test passes, handoff §6).

--- a/docs/impl-m3_zh.md
+++ b/docs/impl-m3_zh.md
@@ -1,0 +1,738 @@
+# dsh-auth M3 实施规格（executable spec）
+
+> 读者：执行实现的编码代理（预期 deepseek v4 flash，**新 session**）。本文档是**决策完备的规格**：
+> 所有判断点已预先关闭，执行者只做翻译，不做设计。
+> 基线：`docs/impl-m2_zh.md`（M2 已交付：守卫 + TokenGate + /auth 端点 + 持久化会话——M3 在其上叠加）。
+> 设计依据：`docs/dsh-auth-plan_zh.md` §5/§6 阶段 2/§8；工程门禁：`docs/development.md`。
+> **本文件是 M3 的唯一权威细则**；与 plan/M1/M2 冲突时以本文件为准。
+>
+> 环境与验证工作流见 `docs/handoff-m2_zh.md`（新 session 必读：服务器访问、沙箱网络限制、M1/M2
+> 踩坑清单——§3/§4/§5 的环境事实对 M3 依然有效）。**禁止自行探索 harness 内部**——需要本文件
+> 之外的事实，停下报告。
+>
+> 已获用户确认的两个方向性决策（2026-08-15）：口令哈希用 **`node:crypto` scrypt**（零新增
+> 原生依赖）；password 模式下 **Bearer = 会话 token**（非共享 token、非 Basic）。
+
+---
+
+## 1. M3 目标
+
+把阶段 2 的"真正登录"落地，`mode: "password"` 从抛错变为完整可用的密码流：
+
+- `$DSH_HOME/auth/users.yaml` 维护管理员凭证（scrypt 哈希，**文件里永不出现明文口令**）；
+- `POST /auth/login` 接受 `username` + `password`，恒时验证 → 发持久化会话 cookie（subject =
+  用户名，审计用）；错误口令/未知用户/禁用用户统一 401（防枚举）；
+- 登录限速：按 IP + 账号双桶计数，失败指数退避，锁定返回 `429 + retry-after`；
+- `Authorization: Bearer <会话 token>` 直接通过守卫（会话查表校验，零每请求 KDF）；
+- 配套 CLI：`dsh-auth user add/list/disable`（生成哈希、原子编辑 users.yaml）；
+- `mode: "token"`（M2 行为）**保持 100% 不变**，作为默认流继续可用。
+
+守卫/会话/自检全部复用 M1/M2，**不改其行为**；本里程碑只加密码流 + CLI。
+
+---
+
+## 2. 冻结决策表（M3 增量；M1 的 D1–D16、M2 的 M1–M22 不变）
+
+| #   | 决策           | 冻结值                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
+| --- | -------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| P1  | 口令哈希       | `node:crypto` **scrypt**（`promisify(scrypt)`），参数 **N=65536, r=8, p=1, keylen=32**，salt = `randomBytes(16)`，**显式 `maxmem: 128 * 1024 * 1024`**（本机实测：N=2¹⁵ 即超过默认 32 MiB maxmem 直接抛 RangeError，必须显式传）。存储为单字符串 `scrypt$<N>$<r>$<p>$<salt b64url>$<hash b64url>`。单次派生 ~150 ms，登录低频可接受                                                                                                                                                                                                                                                                                                                                                                                                                                                |
+| P2  | 验证语义       | `verifyPassword(password, stored)` 解析 stored 的 N/r/p/salt/hash 后按**存储值**的参数重新派生（当前值即 P1，未来调参时旧哈希仍可验证）；N ≤ 2¹⁷、r ≤ 32、p ≤ 4（防 users 文件恶意参数放大内存），salt 段解码 16 字节、hash 段 32 字节，段数/前缀/数字不合法 → `false`（**不抛**）。恒时：`timingSafeEqual`（双方恒 32 字节 Buffer）                                                                                                                                                                                                                                                                                                                                                                                                                                               |
+| P3  | DUMMY_HASH     | 冻结字面量：`scrypt$65536$8$1$enp6enp6enp6enp6enp6eg$qhquFN2piwx7cxC6jYN4yREJCPln_GQTzBbLmm4bj1k`（salt = 16 个 0x7a 字节；口令 `dsh-auth-dummy-password-for-timing-uniformity` 仅出现在测试断言中，**不是秘密**）。未知用户名登录时对该常量跑一次真验证（时序均匀，防用户名枚举）                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 |
+| P4  | users 文件格式 | `$DSH_HOME/auth/users.yaml`：顶层 `{ version: 1, users: { <name>: { passwordHash, totpSecret?, disabled? } } }`。zod 严格校验：顶层与用户条目都 `.strict()`——未知键/`version` 非 1/非法用户名/缺失 `passwordHash` → 文件不可用（503）。`totpSecret`（可选 string）**M3 只解析不使用**（M4）；`disabled` 缺省 `false`                                                                                                                                                                                                                                                                                                                                                                                                                                                               |
+| P5  | username 约束  | `USERNAME_RE = /^[a-zA-Z0-9][a-zA-Z0-9._-]{0,63}$/`（users 文件校验 + CLI 强制）；匹配**大小写敏感**、不做任何规范化。用户名仅作键与审计 subject，不是身份边界                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     |
+| P6  | 文件路径       | config 新增 `usersFile: string`，默认 `""`。`""` 时 apply 内解析：`process.env.DSH_HOME` 存在 → `path.join(env, "auth", "users.yaml")`；否则 `path.join(os.homedir(), ".dsh", "auth", "users.yaml")`（与部署侧 `DSH_HOME=~/dsh-smoke` 启动方式一致，handoff §3.2）。显式 config 原样使用。解析规则是本插件自己的，README 注明                                                                                                                                                                                                                                                                                                                                                                                                                                                      |
+| P7  | 读取语义       | **每次登录尝试重新读文件**（per-operation，CLI 改完立即生效、免重启——与 M2 credentials 语义一致）；**不缓存**。YAML 语法错/schema 错/权限过宽 → 登录 503 `"user store unavailable"` + `log.error`（每次失败都记——登录低频，操作员信号）；文件不存在 → **空用户集** + 进程内首次 `log.warn` 一次（flag 防刷）+ 登录走 401 路径                                                                                                                                                                                                                                                                                                                                                                                                                                                      |
+| P8  | 文件权限       | 与 credentials 的 0600 纪律一致：POSIX 上加载时 `(stat.mode & 0o077) !== 0` → 文件不可用（503）；**win32 跳过检查**（权限无意义，CI 有 windows-latest）。CLI 写入一律 0600（P19）                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  |
+| P9  | 认证结果       | 未知用户 → 对 DUMMY_HASH 验证后 401；口令错误 → 401；`disabled: true` → **仍跑一次真验证**（时序均匀）后 401。三者响应体统一 `"invalid credentials"` + `logger.info("login rejected")`（**不含用户名**——防枚举，日志纪律 P23）                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     |
+| P10 | 登录限速       | 内存态 `LoginRateLimiter`（**重启清零**，README 注明）。常量：`maxFailures=5`、`baseDelaySeconds=30`、`maxDelaySeconds=900`、`windowSeconds=600`；第 n（n≥5）次失败 → 锁定 `min(30 * 2^(n-5), 900)` 秒。锁定期请求 → **429** + `retry-after: <秒>` + text/plain `"too many attempts"` + `logger.info("rate limit exceeded")`，**不增计数、不验证**；锁到期条目清零重计；**失败计数 10 分钟无失败后衰减清零**（滑动窗口，`windowSeconds`）；成功清双桶。IP 取 `req.socket.remoteAddress ?? ""`，**不读 XFF**（可伪造）；`username === ""` 只计 IP 桶；条目上限 10000，超限删最早插入                                                                                                                                                                                                |
+| P11 | mode 语义      | `mode: "password"` 激活 PasswordGate + password 端点（**不再抛错**）；`mode: "token"` 为默认且行为与 M2 **逐字节一致**（`token-gate.ts` 零改动、credentials 接线零改动）。两模式**二选一不可并存**；password 模式不读 credentials 服务、`tokenRef` 配置被忽略                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      |
+| P12 | PasswordGate   | `decide` 顺序：1) 白名单 `/auth`、`/auth/*` → allow；2) cookie：`parseCookieHeader` 非空且 `sessions()?.getByToken(...)` 命中 → allow；3) **Bearer = 会话 token**：`Authorization` 匹配 `/^Bearer\s+(.+)$/i` 后 `sessions()?.getByToken(value)` 命中 → allow（**不比对共享 token、不派生哈希**）；4) deny。同步返回（无 await）。HTTP 与 upgrade 同一 `decide`（guard 侧不变）                                                                                                                                                                                                                                                                                                                                                                                                     |
+| P13 | 登录页         | `login-page.ts` 新增 `passwordLoginPageHtml(next, error?)`：username（`<input type="text" name="username" autocomplete="username" required>`）+ password（`<input type="password" name="password" autocomplete="current-password" required autofocus>`）+ hidden next（escape）+ 同款内联样式。`loginPageHtml`（token 版）原样保留。`GET /auth/login` 恒渲染（不查会话、不重定向，M20 一致）                                                                                                                                                                                                                                                                                                                                                                                       |
+| P14 | 登录端点       | `POST /auth/login`（password 模式）字段 `username`/`password`/`next`，复用 `parseFormBody`（415/413 语义与 M2 完全一致）。成功 → `store.create(username, ttl*1000)` + `buildSetCookie` 4 参 + 302 next + `info("session issued")`。失败 → 401 `"invalid credentials"`；`loadUsers` 失败 → 503 `"user store unavailable"` + `error`；`sessions()` undefined → 503 `"session store unavailable"` + `error`（M2 文案）。429 见 P10。全程 no-store                                                                                                                                                                                                                                                                                                                                     |
+| P15 | 会话语义       | subject = **username**（审计：日志知道哪个凭证产生的会话；不是隔离）。**禁用用户只拦新登录**：已发会话在 TTL 内继续有效（README 注明局限；`revokeBySubject` 留 M4 评估，写 `TODO(auth-m4):`）。每次登录都是新会话（防固定，M6 语义延续）                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
+| P16 | 路由模型       | password 模式注册**同样的 4 条**（prefix `/auth` 404 兜底 + 3 exact），由 `index.ts` 按 mode 二选一装配（不同时注册两条相同 path——webserver 会抛重复）。logout/status 行为与 M2 **完全一致**：logout 仅 POST、next 仅 query、无 body 可幂等调用、`Max-Age=0`；status 仅 GET、**只认 cookie**（Bearer 会话 token 不参与——无状态通道不建会话）                                                                                                                                                                                                                                                                                                                                                                                                                                       |
+| P17 | validateNext   | 提取到新文件 `src/auth-common.ts` 导出；`auth-endpoints.ts` 删私有实现改 import（**行为不变**，M2 测试守护）；`password-endpoints.ts` 同样 import。M8/M20 校验规则逐字保留                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         |
+| P18 | CLI            | `package.json` 增 `"bin": { "dsh-auth": "lib/cli.js" }`；`src/cli.ts` 首行 shebang（tsc 原样保留）。命令面：`user add <name> [--password-stdin] [--disabled]` / `user list` / `user disable <name>`；全局 `--file <path>`（缺省 `defaultUsersFilePath()`）。`add` **要求 `--password-stdin`**（从 stdin 读一行，去尾部 `\r\n`；缺 flag → usage + exit 1）；name 不符 USERNAME_RE / 已存在 → stderr 错误 + exit 1；成功 `out("user <name> added")`。`list` 按用户名排序输出 `<name>` / `<name> (disabled)`（**永不输出哈希**）。`disable` 幂等（已禁用也成功）。未知命令/参数 → usage 到 stderr + exit 1。成功 exit 0。`main(argv, io): Promise<number>` 可注入 io（`out`/`err`/`readLine`）——**禁 `console.*`**，默认 io 用 `process.stdout/stderr.write` + `node:readline` 读一行 |
+| P19 | CLI 写文件     | 经 `writeUsersFile`：`yaml.stringify` 重写**全文件**（注释不保留——README 注明该文件归 CLI 管、勿手写注释）+ 同目录 `<path>.tmp` 写入 + `fs.rename` 原子替换 + mode `0o600`；目录不存在则 `mkdir -p`。序列化时用户按用户名字典序（**显式比较器**——eslint 规则）                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     |
+| P20 | 依赖变更       | runtime 增 **`yaml@^2.9.0`**（本机锁文件已有 2.9.0 传递依赖，公开 npm 源，`lock:check` 通过）；**无其他依赖变化**（devDependencies 不动；scrypt 是内建）。安装必须 `npm install --registry=https://registry.npmjs.org/`                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            |
+| P21 | CSRF 评估      | **M3 仍不加登录 CSRF token**。评估结论：单门模型无用户间隔离——登录 CSRF 唯一影响是会话 subject 审计值被污染（受害者以攻击者身份使用同一共享实例），无权限边界损失；`SameSite=Lax` + 现代浏览器第三方 Set-Cookie 限制进一步收窄；README 注明残余风险，M4 再评估。                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   |
+| P22 | 配置面         | M3 唯一新 config = `usersFile`（P6）。限速常量**不配置化**（`rate-limit.ts` 模块常量）；scrypt 参数不配置化。                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      |
+| P23 | 日志纪律       | 延续 M21：**永不落**口令/用户名（登录相关日志）/哈希/会话 token。password 模式日志事件：`login rejected`、`rate limit exceeded`、`session issued`、`logout`（info）；`user store unavailable: <error.message>`、`session store unavailable`（error）；`users file not found: <path>`（warn，进程内一次）。DUMMY_HASH 与 DUMMY 口令是公开常量不受限；CLI 输出（list、add 确认）不是日志                                                                                                                                                                                                                                                                                                                                                                                             |
+| P24 | 行数预算       | `password-login.ts`（登录 handler 逻辑，≤250）与 `password-endpoints.ts`（路由骨架 + logout/status + 405，≤250）拆两个文件。测试沿 M2 教训拆三个文件（矩阵 §5）。`cli.ts` 单文件 ≤250（usage 文本作文件内常量）                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    |
+| P25 | 测试参数       | 单测/集成测试一律用**真实 scrypt 参数**（不弱化、不注入假参数）；密码类套件预算 ≤10 次派生（每次 ~150 ms）。429 锁定（30s 起）会污染同实例后续登录——**429 场景用独立 ctx/端口实例**（集成测试单独 describe 起新栈），单测用注入时钟 `now`                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| P26 | 装配顺序       | `apply` 内：log → mode 分支（token：`makeTokenResolver` + TokenGate；password：PasswordGate + `usersPath` 解析 + `new LoginRateLimiter()` + `loadUsers`/`verify` 闭包）→ auth 对象一步成型（`sessions: () => auth.sessions` 闭包自引用）+ `provide` → storage 软接（M1 逻辑不动）→ `wrapServer` → 端点注册（按 mode 二选一，包装后的 `server.register`）→ 自检（最后）。apply 内无 await；password 模式**不访问 credentials 服务**                                                                                                                                                                                                                                                                                                                                                 |
+
+---
+
+## 3. 权威契约（M3 新增事实；其余见 impl-m1.md §2 / impl-m2.md §3）
+
+### 3.1 `node:crypto` scrypt（本机 Node 24.13.1 实测）
+
+- `scrypt(password, salt, keylen, options)` 回调式；用 `promisify(scrypt)`。
+- **maxmem 实测**：默认 maxmem = 32 MiB；N=32768/r=8 即抛
+  `RangeError: Invalid scrypt params ... memory limit exceeded`——**必须显式 `maxmem`**（P1 冻结
+  128 MiB；N=65536/r=8 需要 64 MiB 工作内存，留余量）。
+- N=65536/r=8/p=1/keylen=32 实测 ~150 ms/次。
+- `timingSafeEqual` 只接受 Buffer/TypedArray（M2 已冻结，scrypt 输出即 Buffer，双方恒 32 字节）。
+- base64url 长度：16 字节 salt → 22 字符；32 字节 hash → 43 字符。存储串总长固定，格式正则
+  `/^scrypt\$65536\$8\$1\$[A-Za-z0-9_-]{22}\$[A-Za-z0-9_-]{43}$/`（当前参数下的形状断言用）。
+
+### 3.2 `yaml` 包（v2.9.0，公开 npm，已在本仓库锁文件传递依赖中）
+
+- `import { parse, stringify } from "yaml"`；`parse` 返回 `unknown`（不信任输入，一律过 zod 校验）；
+  `stringify` 默认 2 空格缩进、LF。仅用这两个 API，不用 schema/anchors 高级特性。
+- `parse` 对重复键默认**报错抛异常**（YAML 1.2 默认）——正是我们要的严格行为（重复用户名 = 文件
+  不可用）；测试覆盖。
+
+### 3.3 路径与进程环境
+
+- `process.env.DSH_HOME`：部署侧以 `DSH_HOME=~/dsh-smoke <dsh>` 方式启动（handoff §3.2 已验证的
+  机制）；本插件**只读**该变量做 P6 默认路径解析，不探索/不依赖 harness 的任何其他环境事实。
+- `os.homedir()` 兜底（跨平台）；CLI 与插件共享同一个 `defaultUsersFilePath()` 实现
+  （`users-file.ts`），保证 CLI 缺省 `--file` 与插件默认路径一致。
+
+### 3.4 不探索
+
+沿用 M1/M2 纪律：需要本文件未出现的事实（字段、签名、行为）→ 停下报告，不得猜测。
+
+---
+
+## 4. 文件蓝图
+
+每个文件 ≤250 行、函数 ≤80 行、复杂度 ≤15（ESLint error）。M2 文件改动只有三处：
+`auth-endpoints.ts`（P17 import）、`login-page.ts`（新增一个导出）、`index.ts`（P26 装配）。
+`token-gate.ts` / `cookie.ts` / `form-body.ts` / `guard.ts` / `gate.ts` / `session-store.ts` /
+`self-check.ts` **零改动**。
+
+### 4.1 `src/password.ts` —— scrypt 哈希与恒时验证
+
+```ts
+import { randomBytes, scrypt as scryptCb, timingSafeEqual } from "node:crypto";
+import { promisify } from "node:util";
+
+const scrypt = promisify(scryptCb);
+export const SCRYPT_N = 65536;
+export const SCRYPT_R = 8;
+export const SCRYPT_P = 1;
+export const SCRYPT_KEYLEN = 32;
+export const SCRYPT_MAXMEM = 128 * 1024 * 1024;
+/** 未知用户登录时的占位哈希（P3）：salt=16×0x7a 的固定常量，验证成本与真用户一致。 */
+export const DUMMY_HASH =
+  "scrypt$65536$8$1$enp6enp6enp6enp6enp6eg$qhquFN2piwx7cxC6jYN4yREJCPln_GQTzBbLmm4bj1k";
+
+/** 生成 `scrypt$<N>$<r>$<p>$<salt b64url>$<hash b64url>`（salt 16 字节随机）。 */
+export async function hashPassword(password: string): Promise<string>;
+
+/** 恒时验证：解析 stored 参数后重派生（P2），格式/参数非法 → false，不抛。 */
+export async function verifyPassword(password: string, stored: string): Promise<boolean>;
+```
+
+行为约定：`hashPassword` 先 `randomBytes(16)` 再 `scrypt`，拼接用当前常量参数。`verifyPassword`
+先 `stored.split("$")`：6 段、段 0 === `"scrypt"`、N/r/p 为正整数且 N ≤ 2¹⁷、r ≤ 32、p ≤ 4、
+salt/hash 段 base64url 解码后 16/32 字节——任一不满足 → `false`；按**解析出的**参数
+`scrypt(password, salt, 32, { N, r, p, maxmem: SCRYPT_MAXMEM })` 后 `timingSafeEqual`。派生异常
+（内存不足等）→ catch 后 `false`。
+
+### 4.2 `src/rate-limit.ts` —— 双桶登录限速
+
+```ts
+export interface RateLimitOptions {
+  maxFailures?: number; // 默认 5
+  baseDelaySeconds?: number; // 默认 30
+  maxDelaySeconds?: number; // 默认 900
+  windowSeconds?: number; // 默认 600：失败计数衰减窗口（见下）
+  now?: () => number; // 默认 Date.now；测试注入
+}
+
+export type RateLimitCheck = { allowed: true } | { allowed: false; retryAfterSeconds: number };
+
+export class LoginRateLimiter {
+  constructor(options?: RateLimitOptions);
+  check(ip: string, account: string | undefined): RateLimitCheck;
+  recordFailure(ip: string, account: string | undefined): void;
+  recordSuccess(ip: string, account: string | undefined): void;
+}
+```
+
+行为约定：
+
+- 内部两个 `Map<string, { failures: number; lockUntil: number; lastFailureAt: number }>`
+  （`byIp` / `byAccount`）；`account === undefined || account === ""` 时只动 IP 桶。
+- `check`：任一桶 `lockUntil > now` → `{ allowed: false, retryAfterSeconds: max(1, ceil((lockUntil-now)/1000)) }`
+  （取两桶最大）；`lockUntil <= now` 且 failures > 0 → 清零（锁到期自然重试）；**失败衰减**：
+  failures > 0 且 `now - lastFailureAt > windowSeconds * 1000` → 清零（1–4 次失败 10 分钟无后续
+  失败即遗忘，防慢泄漏）；同时修剪：删除 `failures === 0` 的条目；总条目数 > 10000 → 删除
+  **最早插入**的（Map 迭代序）直到 ≤ 10000。
+- `recordFailure`：对应桶 `failures++`、`lastFailureAt = now`；若 `failures >= maxFailures` →
+  `lockUntil = now + min(baseDelay * 2 ** (failures - maxFailures), maxDelay) * 1000`。
+- `recordSuccess`：删除对应桶条目。
+- 端点锁定期**不调** `recordFailure`（429 短路，P10）——锁定时长由失败序列决定，不被延长。
+
+### 4.3 `src/users-file.ts` —— users.yaml 加载/校验/原子写
+
+```ts
+import { z } from "zod";
+import { parse as parseYaml, stringify } from "yaml";
+
+export const USERNAME_RE = /^[a-zA-Z0-9][a-zA-Z0-9._-]{0,63}$/;
+
+export interface UserRecord {
+  passwordHash: string;
+  totpSecret?: string; // M3 解析不使用（M4）
+  disabled: boolean;
+}
+
+export interface UsersSnapshot {
+  users: Map<string, UserRecord>;
+}
+
+/** users 文件不可用（语法/schema/权限）。message 面向操作员，可落日志。 */
+export class UsersFileError extends Error {}
+
+/** 加载结果：`missing` 区分"文件不存在"与"文件存在但无用户"（供 warn-once，P7）。 */
+export interface UsersLoadResult {
+  snapshot: UsersSnapshot;
+  missing: boolean; // ENOENT → true（快照为空）；解析/权限失败 → throw，不走此通道
+}
+
+/** P6：DSH_HOME env → ~/.dsh/auth/users.yaml。 */
+export function defaultUsersFilePath(): string;
+
+/** 每次登录现读（P7）。ENOENT → `{ snapshot: 空, missing: true }`（不抛）；否则 P7/P8 失败语义。 */
+export async function loadUsersFile(path: string): Promise<UsersLoadResult>;
+
+/** CLI 用：全量序列化 + 原子替换 + 0600（P19）。 */
+export async function writeUsersFile(path: string, snapshot: UsersSnapshot): Promise<void>;
+```
+
+行为约定：
+
+- `loadUsersFile`：`fs.stat` → ENOENT → 返回 `{ snapshot: 空快照, missing: true }`（**不抛**）；
+  POSIX 且 `(mode & 0o077) !== 0` →
+  throw `UsersFileError("users file has insecure permissions: <path>")`；win32 跳过权限检查。
+  `readFile("utf8")` → `parseYaml` → zod 校验。zod schema（v4，`z.object({...}).strict()` 顶层与
+  用户条目都 strict）：
+  ```ts
+  const userRecordSchema = z
+    .object({
+      passwordHash: z.string().min(1),
+      totpSecret: z.string().optional(),
+      disabled: z.boolean().optional(),
+    })
+    .strict();
+  const usersFileSchema = z
+    .object({
+      version: z.literal(1),
+      users: z.record(z.string(), userRecordSchema),
+    })
+    .strict();
+  ```
+  解析/校验失败 → throw `UsersFileError(<yaml 或 zod 的消息前缀 "invalid users file">)`；
+  用户名逐一 `USERNAME_RE` 校验（`superRefine` 或 load 后循环）——非法即 throw。成功后
+  `Map`（`disabled` 补 `false`），返回 `{ snapshot, missing: false }`。yaml parse 抛错（含重复键）
+  → 同样包装为 `UsersFileError`。
+- `writeUsersFile`：`mkdir(dirname, { recursive: true })` → `stringify({ version: 1, users: 对象 })`
+  （用户按用户名字典序，**显式比较器** `(a, b) => (a < b ? -1 : a > b ? 1 : 0)`）→
+  `writeFile(path + ".tmp", text, { mode: 0o600 })` → `rename` → 目标路径。幂等可重复调用。
+
+### 4.4 `src/password-gate.ts` —— password 模式门
+
+```ts
+import type { IncomingMessage } from "node:http";
+import type { Gate, GuardKind } from "./gate.js";
+import type { SessionStore } from "./session-store.js";
+import { AUTH_PATH_PREFIX } from "./guard.js";
+import { parseCookieHeader } from "./cookie.js";
+
+export interface PasswordGateOptions {
+  sessions: () => SessionStore | undefined; // M16 同形访问器
+  cookieName: string;
+}
+
+export class PasswordGate implements Gate {
+  constructor(options: PasswordGateOptions);
+  decide(req: IncomingMessage, kind: GuardKind, pathname: string): "allow" | "deny";
+}
+```
+
+`decide` 顺序照 P12 实现（白名单 → cookie 会话 → Bearer 会话 token → deny）；**同步返回**，无
+async、无 KDF、无文件 IO。`sessions()` 返回 undefined 时 cookie 与 bearer 通道都跳过 → deny
+（与 M2 一致：会话层不可用时门恒 deny，白名单除外）。`kind` 参数沿用 `Gate` 接口（password 门
+不使用，签名一致）。
+
+### 4.5 `src/auth-common.ts` —— 端点共享纯函数
+
+```ts
+/** M8+M20 逐字保留：单个 `/` 开头、非 `//`、无 `\`、非 /auth*；否则回落 `/`。 */
+export function validateNext(next: string): string;
+```
+
+仅此一个导出。`auth-endpoints.ts` 删掉私有实现（L176–187），改 `import { validateNext } from "./auth-common.js"`；
+`queryOf`/`methodNotAllowed` 留在各自文件（不提取）。本文件无独立测试文件——由两端点套件覆盖
+（覆盖率达标即可）。
+
+### 4.6 `src/login-page.ts` —— 新增 password 变体
+
+```ts
+/** password 模式登录页：username + password 两字段（P13）；next/error 全部 HTML-escape。 */
+export function passwordLoginPageHtml(next: string, error?: string): string;
+```
+
+复用文件内 `escapeHtml` 与同款样式块（可提取文件内私有模板函数，但导出只增这一个）。token 版
+`loginPageHtml` **原样保留**。标题与按钮文案 `Sign in`（区别于 token 版 `Unlock`）。
+
+### 4.7 `src/password-login.ts` —— POST /auth/login 处理逻辑
+
+```ts
+import type { IncomingMessage, ServerResponse } from "node:http";
+import type { SessionStore } from "./session-store.js";
+import type { UsersLoadResult, UsersSnapshot } from "./users-file.js";
+import type { LoginRateLimiter } from "./rate-limit.js";
+
+export interface PasswordLoginDeps {
+  sessions: () => SessionStore | undefined;
+  cookieName: string;
+  cookieSecure: boolean;
+  sessionTtl: number; // 秒
+  usersPath: string; // 仅用于"文件缺失"warn 消息（P23）
+  loadUsers: () => Promise<UsersLoadResult>; // index.ts 注入 loadUsersFile(usersPath) 闭包
+  verify: (password: string, storedHash: string) => Promise<boolean>; // 与 verifyPassword 同形，index.ts 直接注入
+  limiter: LoginRateLimiter;
+  logger: {
+    error(message: unknown): void;
+    info(message: unknown): void;
+    warn(message: unknown): void;
+  };
+}
+
+/** POST /auth/login（password 模式）。完成全部响应写出（含 415/413/401/429/503/302）。 */
+export async function handlePasswordLogin(
+  deps: PasswordLoginDeps,
+  req: IncomingMessage,
+  res: ServerResponse,
+): Promise<void>;
+```
+
+流程照此实现（顺序冻结，不得重排）：
+
+1. `parseFormBody(req)`——带 `status` 的错误（415/413）→ 写对应响应（413 先
+   `res.setHeader("connection", "close")`，M19 复刻）；**不带 `status` 的异常向上抛**。
+2. `username = params.get("username") ?? ""`；`password = params.get("password") ?? ""`；
+   `next = validateNext(params.get("next") ?? "/")`；`ip = req.socket.remoteAddress ?? ""`。
+3. `const check = deps.limiter.check(ip, username === "" ? undefined : username)`；
+   锁定 → `429` + `retry-after: <check.retryAfterSeconds>` + text/plain `"too many attempts"` +
+   no-store + `info("rate limit exceeded")`；**return（不验证、不增计数）**。
+4. `let users: UsersSnapshot; let missing = false;` `try { const loaded = await deps.loadUsers(); users = loaded.snapshot; missing = loaded.missing; } catch (error) {`
+   → 503 `"user store unavailable"` + no-store +
+   `error("user store unavailable: " + (error instanceof Error ? error.message : String(error)))`；
+   **return（系统错误不计失败）**。`}`
+   `if (missing && !warnedMissing) { warnedMissing = true; deps.logger.warn("users file not found: " + deps.usersPath + " (all password logins rejected)"); }`
+   （`warnedMissing` 为 handlePasswordLogin 模块级 flag——插件单实例，等价进程级一次；P7/P23。）
+5. `const user = users.users.get(username);`
+   `const ok = await deps.verify(password, user?.passwordHash ?? DUMMY_HASH);`（DUMMY_HASH 从
+   `./password.js` import——未知用户时序均匀，P3。**注意参数顺序与 verifyPassword 同形
+   `(password, storedHash)`**——TS 结构兼容不检查参数名，顺序写反会在真实路径恒 401，实施时
+   已踩并修正）。
+6. `if (!ok || user === undefined || user.disabled) { deps.limiter.recordFailure(ip, username === "" ? undefined : username);`
+   → 401 `"invalid credentials"` + no-store + `info("login rejected")`；return。`}`。
+7. `deps.limiter.recordSuccess(ip, username === "" ? undefined : username);`
+8. `const store = deps.sessions();` undefined → 503 `"session store unavailable"` + no-store +
+   `error("login failed: session store unavailable")`；return。
+9. `const { token: sessionToken } = await store.create(username, deps.sessionTtl * 1000);` →
+   `set-cookie`（`buildSetCookie(deps.cookieName, sessionToken, deps.sessionTtl, deps.cookieSecure)`）
+   - 302 `{ location: next }` + no-store + `info("session issued")`。
+
+### 4.8 `src/password-endpoints.ts` —— password 模式路由骨架
+
+```ts
+import { AUTH_PATH_PREFIX, type HttpHandler } from "./guard.js";
+import { buildSetCookie, type SessionStore } from "./session-store.js";
+import { parseCookieHeader } from "./cookie.js";
+import { passwordLoginPageHtml } from "./login-page.js";
+import { validateNext } from "./auth-common.js";
+import { handlePasswordLogin, type PasswordLoginDeps } from "./password-login.js";
+
+export interface PasswordEndpointsDeps extends PasswordLoginDeps {
+  /** 注册路由（index.ts 传入包装后的 server.register；被守卫包装但被 gate 白名单放行）。 */
+  register(route: { kind: "exact" | "prefix"; path: string; handler: HttpHandler }): () => void;
+}
+
+/** 注册 prefix `/auth` 兜底 + 三个 exact 端点（password 模式）；返回合并 disposer。 */
+export function registerPasswordEndpoints(deps: PasswordEndpointsDeps): () => void;
+```
+
+结构照 `auth-endpoints.ts`（合并 disposer、track 收集）：4 条路由——
+
+- prefix `/auth` → 恒 404 `"not found"` + no-store（P16）。
+- exact `/auth/login`：GET → `validateNext(query.get("next") ?? "/")` + 200 text/html +
+  `passwordLoginPageHtml(next)`（恒渲染）；POST → `handlePasswordLogin(deps, req, res)`；
+  其他 → 405 + `allow: GET, POST`。
+- exact `/auth/logout`：仅 POST（其他 405 + `allow: POST`）——逻辑与 M2 `logout` 逐字一致
+  （next 仅 query、revoke 幂等、`buildSetCookie(name, "", 0, cookieSecure)` 清 cookie、302、
+  `info("logout")`）。
+- exact `/auth/status`：仅 GET（其他 405 + `allow: GET`）——逻辑与 M2 `handleStatus` 逐字一致
+  （只认 cookie，Bearer 不参与）。
+
+`methodNotAllowed`/`queryOf`/catch-all handler 在本文件内实现（与 `auth-endpoints.ts` 的对应
+函数**内容一致但各自私有**——重复 ~35 行被接受：token 流已冻结、两流生命周期独立；若 M4 需要
+合并再动）。全部响应 no-store。
+
+### 4.9 `src/cli.ts` —— dsh-auth 用户管理 CLI
+
+```ts
+#!/usr/bin/env node
+import { pathToFileURL } from "node:url";
+// users-file / password 模块 import 同 src 惯例（相对 .js 后缀）
+
+export interface CliIo {
+  out(line: string): void;
+  err(line: string): void;
+  readLine(): Promise<string>; // stdin 一行，去尾部 \r\n；EOF → ""
+}
+
+/** 返回进程退出码。所有参数/IO 经 argv/io 注入（可测，禁 console.*）。 */
+export async function main(argv: string[], io: CliIo): Promise<number>;
+
+// 文件底部入口（保持最后）：
+// if (import.meta.url === pathToFileURL(process.argv[1] ?? "").href) {
+//   void main(process.argv.slice(2), defaultIo).then((code) => { process.exitCode = code; });
+// }
+```
+
+行为约定：
+
+- 用法文本（冻结，两处 usage 共用一份常量）：
+  ```
+  Usage:
+    dsh-auth user add <name> --password-stdin [--disabled] [--file <path>]
+    dsh-auth user list [--file <path>]
+    dsh-auth user disable <name> [--file <path>]
+  ```
+- 参数解析：`--file` 后跟一个值（原样取用，不做路径展开）；`--disabled`、`--password-stdin`
+  为布尔 flag；不认识的 token / 非 `user` 子命令 / 未知子命令 → err(usage) + return 1。
+- `add`：name 必须匹配 `USERNAME_RE`（否则 err + 1）；`--password-stdin` 缺失 → err(usage) + 1；
+  `(await loadUsersFile(file)).snapshot` → 已存在同名 → err(`user <name> already exists`) + 1；
+  `readLine()` 为空 → err(`empty password`) + 1；`hashPassword(pw)` → 加入快照（`disabled` 按
+  flag，默认 false）→ `writeUsersFile` → out(`user <name> added`)。
+- `list`：`(await loadUsersFile(file)).snapshot` → 按用户名字典序（显式比较器）逐行 out(`<name>` /
+  `<name> (disabled)`)。文件缺失（`missing: true`）→ 无输出、exit 0。
+- `disable`：`(await loadUsersFile(file)).snapshot` → 不存在 → err(`user not found`) + 1；
+  置 `disabled: true` → `writeUsersFile` → out(`user <name> disabled`)（已禁用同输出，幂等）。
+- 所有 `loadUsersFile`/`writeUsersFile` 抛错（`UsersFileError` 或 IO）→ err(message) + 1。
+- `defaultIo`：`out = (l) => process.stdout.write(l + "\n")`、err 同 stderr、`readLine` 用
+  `node:readline` 对 `process.stdin` 取一行后 close。
+
+### 4.10 `src/index.ts` —— 装配变更（P26；其余 M1/M2 逻辑不动）
+
+1. `AuthConfig` 增 `usersFile: string`（注释：`""` = 按 P6 解析默认路径；password 模式专用，
+   token 模式忽略）；`Config` 增 `usersFile: z.string().default("")`。`mode` 的 JSDoc 更新为
+   "token（M2）/ password（M3）"。
+2. **删除** apply 开头的 `mode === "password" → throw`（M2 的 L99–101）。
+3. `resolveToken` 仅 token 模式构造（password 模式不构造、不访问 credentials）：
+   ```ts
+   const resolveToken = config.mode === "token" ? makeTokenResolver(ctx, config, log) : undefined;
+   ```
+4. password 分支专属常量（token 模式也计算、无害——`usersPath`/`limiter` 都被第 6 步三元表达式
+   引用，不算未使用变量；`makeTokenResolver` 惰性取服务，password 模式下从未被调用）：
+   ```ts
+   const usersPath = config.usersFile === "" ? defaultUsersFilePath() : config.usersFile;
+   const limiter = new LoginRateLimiter();
+   ```
+5. `auth` 一步成型（P26；闭包自引用在 decide 时才求值）：
+   ```ts
+   const auth: AuthService = {
+     sessions: undefined,
+     gate:
+       config.mode === "password"
+         ? new PasswordGate({ sessions: () => auth.sessions, cookieName: config.cookieName })
+         : new TokenGate({
+             // token 模式下 makeTokenResolver 必返回函数；`??` 兜底仅类型对齐（不可达且 fail-closed）
+             resolveToken: resolveToken ?? (async () => undefined),
+             sessions: () => auth.sessions,
+             cookieName: config.cookieName,
+           }),
+   };
+   ctx.provide("auth", auth);
+   ```
+6. 端点注册按 mode 二选一（自检仍在端点注册**之后**；token 分支的 `validateToken` 闭包同样用
+   `resolveToken ?? (async () => undefined)` 兜底）：
+   ```ts
+   ctx.effect(
+     () =>
+       config.mode === "password"
+         ? registerPasswordEndpoints({
+             register: (route) => server.register(route),
+             sessions: () => auth.sessions,
+             cookieName: config.cookieName,
+             cookieSecure: config.cookieSecure,
+             sessionTtl: config.sessionTtl,
+             usersPath,
+             loadUsers: () => loadUsersFile(usersPath),
+             verify: verifyPassword,
+             limiter,
+             logger: log,
+           })
+         : registerAuthEndpoints({
+             // M2 参数逐字保留：register/sessions/cookieName/cookieSecure/sessionTtl/logger 同上
+             validateToken: async (token) => {
+               const stored = await (resolveToken ?? (async () => undefined))();
+               return stored !== undefined && safeEqual(token, stored);
+             },
+           }),
+     "dsh-auth: auth endpoints",
+   );
+   ```
+7. storage 软接、`wrapServer`、自检：**零改动**（顺序保持：storage → wrap → endpoints → self-check）。
+
+### 4.11 `package.json` / 文档
+
+- `dependencies` 增 `"yaml": "^2.9.0"`（排序按既有字母序）；顶层增
+  `"bin": { "dsh-auth": "lib/cli.js" }`。`files: ["lib"]` 已含 CLI 产物；`main`/`exports` 不动。
+- `README.md` 新增一节（消费者契约）：`mode: "password"` 配置、users 文件格式与权限（0600、
+  归 CLI 管）、CLI 用法、token → password 迁移说明、已知局限（限速内存态重启清零；禁用用户
+  不吊销已发会话；无 CSRF token 的残余风险；Bearer 会话 token 语义；XFF 不信任）。
+- `docs/development.md` 的 `## Structure` 树按 §4 新文件更新。
+- `AGENTS.md` 增两行指针：M3 规格 `docs/impl-m3_zh.md` + 交接 `docs/handoff-m3_zh.md`（后者由执行
+  session 收尾时写，见 DoD 6）。
+
+---
+
+## 5. 测试矩阵
+
+M1/M2 测试**全保留且必须原样绿**（`auth-endpoints*.test.ts` 不因 P17 改动而变——validateNext
+行为不变）。`src/index.test.ts` 按 §4.10 适配。新增（全部显式 vitest import；大套件按 describe
+拆文件，每个 ≤250 行）：
+
+**`src/password.test.ts`** —
+
+1. `hashPassword` 输出匹配 `/^scrypt\$65536\$8\$1\$[A-Za-z0-9_-]{22}\$[A-Za-z0-9_-]{43}$/`；
+   两次调用 salt 不同（串不等）。
+2. roundtrip：`verifyPassword(pw, await hashPassword(pw)) === true`。
+3. 错口令 → false；空串口令 hash/verify 正常（hash("") 可验证）。
+4. `verifyPassword` 坏输入全分支：非 6 段、前缀错、N/r/p 非数字、N > 2¹⁷、salt 段长度错、非法
+   base64url → 全部 false 且不抛。
+5. DUMMY_HASH 已知向量：`verifyPassword("dsh-auth-dummy-password-for-timing-uniformity", DUMMY_HASH) === true`；
+   其他口令 → false（DUMMY 口令字面量不是秘密，允许出现在断言）。
+6. 参数演进兼容：手工构造合法旧参数哈希（`scryptSync` 按 N=2¹⁴ 生成，拼成
+   `scrypt$16384$8$1$<salt>$<hash>`）→ 在模块常量 N=2¹⁶ 下 `verifyPassword` 仍成功（证明验证
+   走 **stored 自带参数**而非当前常量；注意 scrypt 的 N 参与派生，**改 N 段必须同时重派生**
+   才成立——原"替换 N 段"写法是错的，实施时已修正为上述构造法）。
+
+**`src/rate-limit.test.ts`**（注入 `now`）—
+
+1. 前 4 次失败 → check 恒 allowed。
+2. 第 5 次失败后 check → locked，`retryAfterSeconds === 30`。
+3. 第 6 次失败后 → 60；增长到 900 封顶（多打几次断言封顶）。
+4. 锁定期 check locked（不再 recordFailure）。
+5. 时钟越过 lockUntil → check allowed 且计数已清零（失败重新从 1 计）。
+6. `recordSuccess` 后 check allowed、计数清零。
+7. IP 桶与账号桶独立：同 IP 不同账号失败互不锁定对方；不同 IP 同一账号被账号桶锁定。
+8. `account: undefined`/`""` 只动 IP 桶。
+9. 衰减与修剪：注入 now——3 次失败后推进时钟 10 分钟 → check 清零且条目被删（后续 check 观察
+   不到计数）；条目数超 10000 删最早——上限是模块常量不导出，测试用 10001 个**互异 key** 各
+   `recordFailure` 一次（failures=1，不会被普通修剪删掉）灌满后调一次 `check`，断言 Map 大小
+   回落到 10000 且最早插入的 key 已被淘汰（各 ~几 ms，可行）。
+
+**`src/users-file.test.ts`**（`mkdtemp` 临时目录；`it.skipIf(process.platform === "win32")` 的
+用例用 vitest 条件跳过）—
+
+1. `defaultUsersFilePath`：`vi.stubEnv("DSH_HOME", tmp)` → 拼出 `<tmp>/auth/users.yaml`；
+   无 env → `path.join(os.homedir(), ".dsh", "auth", "users.yaml")`（断言前缀 homedir；测试后
+   `vi.unstubAllEnvs()`）。
+2. load：合法文件（两个用户，一个带 totpSecret/disabled）→ Map 内容正确、disabled 缺省 false。
+3. 文件不存在 → `{ snapshot: 空 Map, missing: true }`（不抛）；存在且合法 → `missing: false`。
+4. 坏 YAML（语法）→ `UsersFileError`；重复键 YAML → `UsersFileError`。
+5. schema 错：version 非 1、未知顶层键、未知用户字段、缺失 passwordHash、非法用户名、totpSecret
+   非字符串 → 全部 `UsersFileError`。
+6. 权限过宽（`writeFileSync` 后 `chmodSync(0o644)`）→ `UsersFileError`（POSIX only）。
+7. write：快照 → 文件内容精确（yaml 结构、用户名字典序、`disabled: true` 显式）；mode 0600
+   （`statSync` 断言，POSIX only）；`.tmp` 残留不存在；目录不存在时自动创建。
+
+**`src/password-gate.test.ts`**（fake req headers + fake sessions（MemTable 思路复用））—
+
+1. 白名单：`/auth`、`/auth/login`、`/auth/whatever` → allow（无凭证）。
+2. cookie 通道：有效会话 → allow；未知/过期/revoked token → deny；cookie 头缺失 → deny。
+3. Bearer 通道：`Authorization: Bearer <会话 token>` → allow；未知 token → deny；`bearer` 小写
+   前缀可接受；带前缀格式错误 → deny。
+4. `sessions: () => undefined`：cookie 与 bearer 都跳过 → deny（白名单除外）。
+5. 无凭证 → deny。返回值为同步 `"allow" | "deny"`（非 Promise）。
+
+**`src/password-endpoints.test.ts`**（fake register/limiter/loadUsers/verify/sessions；按行数拆三
+文件：`password-endpoints.test.ts` 注册形状/GET login/logout/status，
+`password-endpoints.login.test.ts` POST login，`password-endpoints.methods.test.ts`
+405/兜底/415/413/页面 escape——矩阵合并描述）—
+
+1. 注册形状：4 条——prefix `/auth`、exact `/auth/login`、`/auth/logout`、`/auth/status`。
+2. GET login：200 + HTML 含 `<form`、`name="username"`、`name="password"`；hidden next escape
+   （`next="/x?a=1&b=2"` → `&amp;`）；已有有效会话也恒 200 渲染（M20 一致）。
+3. POST login 成功：fake verify true → 302 location=next + set-cookie 精确串（secure=true/false
+   两态）+ `sessions().create` 被调（subject = username、ttl = sessionTtl*1000）+
+   `limiter.recordSuccess` 被调 + `info("session issued")`。
+4. POST login 失败：verify false → 401 `"invalid credentials"` + `info("login rejected")` +
+   `recordFailure` 被调、无会话创建；未知用户（loadUsers 不含该名）→ verify 收到 **DUMMY_HASH**
+   - 401；禁用用户 → verify 收到该用户真哈希 + 401（P9：三态统一）。
+5. POST login 429：limiter 预置 locked → 429 + `retry-after` 数值 + `info("rate limit exceeded")`；
+   **verify 未被调**（锁定期不验证）。
+6. POST login 503：fake loadUsers reject → 503 `"user store unavailable"` + error 日志 + 不计
+   失败；`sessions()` undefined → 503 `"session store unavailable"`。
+   6b. POST login 文件缺失：fake loadUsers 返回 `{ snapshot: 空, missing: true }` → 401
+   `"invalid credentials"`（空用户集）+ **首次** `warn("users file not found: ...")` 一次；
+   第二次登录不再重复 warn（模块级 flag）。
+7. POST login next 校验：`//evil.com` → `/`；`/ok/path` → 原样；`/auth/login`、`/auth/x` → `/`
+   （M20 回环防护沿用）。
+8. POST login 空 username：只动 IP 桶（fake limiter 断言 account 参数 undefined）；成功路径
+   username 非空 → account 参数 = username。
+9. POST logout：revoke 被调 + set-cookie 含 `Max-Age=0` + 302；next 仅 query；无 body/无
+   content-type 可用；cookie 缺失也 302 幂等（M22 复刻）。
+10. GET status：有效 cookie → `{"authenticated":true}`；无 → false；带 `Authorization: Bearer`
+    头不影响（只认 cookie，M5）。
+11. method 分发：`DELETE /auth/login` → 405 + `allow: GET, POST`；`GET /auth/logout` → 405；
+    `POST /auth/status` → 405。
+12. prefix 兜底：`/auth/whatever` → 404 + no-store。
+13. 415/413：非 urlencoded → 415；超 16 KiB → 413 + `connection: close` + 不调 `req.destroy`
+    （M19 复刻）。
+14. `passwordLoginPageHtml`：直接断言 HTML 含两字段与 escape（本文件或 login-page 相关文件内）。
+
+**`src/cli.test.ts`**（fake `CliIo`：`out/err` 收集到数组、`readLine` 返回预置行）—
+
+1. `add` 全流程：mkdtemp 文件路径 + `--password-stdin` → exit 0、out 含 `user alice added`、
+   文件已建且 mode 0600（POSIX only）、再 `loadUsersFile` 读回含 alice；用 `verifyPassword` 验证
+   文件里的哈希能验证该口令（真实 scrypt 一次）。
+2. `add` 失败分支：缺 `--password-stdin` → exit 1 + usage；name 非法（含空格/开头数字）→ exit 1；
+   同名已存在 → exit 1 + `already exists`；stdin 空行 → exit 1。
+3. `add --disabled` → 读回 `disabled: true`。
+4. `list`：预置两用户（一禁用）→ 输出两行、字典序、`(disabled)` 标记；空文件 → 无输出 exit 0。
+5. `disable`：→ exit 0 + `user alice disabled` + 读回 disabled；不存在 → exit 1 + `not found`；
+   再次 disable → 幂等 exit 0。
+6. 未知子命令/未知 flag → exit 1 + usage 到 err。
+7. `--file` 指向不存在目录 → 自动创建（writeUsersFile 语义）。
+
+**`src/index.test.ts` 适配**（既有用例全保留，新增/修改）—
+
+1. `mode: "password"` **不再抛错**（M2 的抛错用例删除）；gate 为 `PasswordGate` 实例。
+2. `mode: "token"`（默认）gate 仍为 `TokenGate`；fake ctx 记录 `get("credentials")` 被访问。
+3. password 模式：fake ctx 断言 `get("credentials")` **未被访问**；端点注册走 password 版
+   （fake register 记录 4 条路由，与 token 版同形）。
+4. `usersFile` 默认解析：`vi.stubEnv("DSH_HOME", tmp)` 下挂载 password 模式 + `vi.mock("./password-endpoints.js")`
+   捕获 `registerPasswordEndpoints` 收到的 deps → 断言 `deps.usersPath === path.join(tmp, "auth", "users.yaml")`；
+   显式 `usersFile: "/x.yaml"` → `deps.usersPath === "/x.yaml"`。测试后 `vi.unstubAllEnvs()`。
+5. Config 默认值：`{}` → 含 `usersFile: ""`。
+6. 既有注销/自检/双缺失用例保持绿（token 分支）。
+
+**`src/integration.password.test.ts`**（真实入口路径）— 真实 cordis + **真实 storage 栈**
+（Storage → storage-json → storage-domain，挂载顺序同 `integration.auth.test.ts`）+ 真实
+WebServer + 真实 users 文件（`mkdtemp` root；`beforeAll` 用 `hashPassword` + `writeUsersFile`
+预置 `admin`（口令 `<test-password>`）与 `disableduser`（`disabled: true`））+ 本插件
+`config { mode: "password", cookieSecure: false, usersFile: <tmp>/users.yaml }`：
+
+1. 全流程：`GET /auth/login` → 200 含 `name="username"`；错口令 → 401；对 → 302 + set-cookie +
+   location；带 cookie `GET /__probe` → 200；无 cookie → 302（HTML accept）/ 401（JSON accept）；
+   `Authorization: Bearer <cookie 里的会话 token>` → 200；Bearer 错 → 401；`POST /auth/logout?next=/`
+   带 cookie → 302 + Max-Age=0；原 cookie 再访问 → 401。
+2. subject 审计：登录成功后 `ctx.get("auth")!.sessions!.getByToken(<cookie token>)!.subject === "admin"`。
+3. 禁用/未知用户：disableduser → 401；`ghost` → 401（响应体一致 `invalid credentials`）。
+4. 文件不可用：改写 users.yaml 为坏 YAML → 登录 503；恢复 → 401 正常。文件缺失（指向不存在的
+   路径，独立实例）→ 登录 401（空用户集）。
+5. WS 通道：带会话 cookie 的 upgrade → 101；`Authorization: Bearer <会话 token>` 的 upgrade →
+   101；无凭证 → 401 拒握手（复用 M1 `requestUpgradeStatus` 模式 + 变体头）。
+6. 429 限速：**独立 describe + 新 ctx/端口**（P25——不污染共享实例的 limiter）：连错 5 次 →
+   第 6 次 429 + `retry-after` 头；随后正确口令也 429（锁定中）。
+7. token 模式回归由既有 `integration.auth.test.ts` 承担（不动、必须绿）。
+
+---
+
+## 6. 实施顺序（每步保持 `npm run verify` 绿）
+
+1. `package.json`（yaml + bin）+ `npm install --registry=https://registry.npmjs.org/`。
+2. `src/password.ts` + `src/password.test.ts`。
+3. `src/rate-limit.ts` + `src/rate-limit.test.ts`。
+4. `src/users-file.ts` + `src/users-file.test.ts`。
+5. `src/auth-common.ts`（提取 validateNext）+ `auth-endpoints.ts` 改 import——**立即跑
+   `npm run test -- src/auth-endpoints.test.ts src/auth-endpoints.login.test.ts src/auth-endpoints.methods.test.ts`
+   证明 M2 行为未变**。
+6. `src/password-gate.ts` + `src/password-gate.test.ts`。
+7. `src/login-page.ts` 增量（`passwordLoginPageHtml`，随第 8/9 步测试覆盖）。
+8. `src/password-login.ts`（行数拆分件，测试经第 9 步）。
+9. `src/password-endpoints.ts` + 三个测试文件（`password-endpoints.test.ts` /
+   `password-endpoints.login.test.ts` / `password-endpoints.methods.test.ts`）。
+10. `src/cli.ts` + `src/cli.test.ts`。
+11. `src/index.ts` 装配 + `src/index.test.ts` 适配。
+12. `src/integration.password.test.ts`。
+13. 文档：`docs/development.md` Structure 树、`README.md`（密码模式/CLI/users 文件契约）、
+    `AGENTS.md`（M3 指针）。
+14. `npm run build` + `lib/` 与 `src/` 同批；`git diff --exit-code -- lib` 通过。
+15. 服务器端到端冒烟（DoD 4）。
+16. 收尾写 `docs/handoff-m3_zh.md`（DoD 6）。
+
+---
+
+## 7. Definition of Done
+
+1. `npm run verify` 全绿（format/lint/type-check/coverage ≥80%/lock:check）。
+2. `npm run build` + `lib/` 与 `src/` 同批；`git diff --exit-code -- lib` 通过。
+3. `npm run test -- src/integration.password.test.ts src/integration.auth.test.ts src/integration.guard.test.ts src/integration.session.test.ts` 单独跑绿（token 模式回归 + password 真实路径）。
+4. **服务器端到端冒烟**（环境事实见 handoff §3；**本机 loopback 不可达，一律在服务器上验证**）：
+   1. 同步：`rsync -az --exclude node_modules --exclude .git /Users/randal/source/dsh-auth/ ubuntu:/tmp/dsh-auth-test/`
+      → 服务器 `cd /tmp/dsh-auth-test && npm install --registry=https://registry.npmjs.org/ && npm run build`。
+   2. 建用户（真实 CLI 路径）：
+      ```bash
+      ssh ubuntu 'printf "%s\n" "<test-password>" | node /tmp/dsh-auth-test/lib/cli.js user add admin --password-stdin --file ~/dsh-smoke/auth/users.yaml'
+      ssh ubuntu 'node /tmp/dsh-auth-test/lib/cli.js user list --file ~/dsh-smoke/auth/users.yaml'
+      ssh ubuntu 'stat -c "%a" ~/dsh-smoke/auth/users.yaml'   # 期望 600
+      ```
+   3. overlay `~/dsh-smoke/cordis.patch.yml`：`dsh-auth` 行 config 改为
+      `{ mode: "password", cookieSecure: false }`（M1 探针行确认已删——handoff §5.3）；重启实例
+      （`pkill -f "[d]sh --profile web --port 3081"` 与启动**分两个 ssh 调用**，handoff §6 教训；
+      `nohup ... > ~/dsh-smoke/boot.log 2>&1 < /dev/null &`，等 ~25s）。
+   4. 验证序列（**先跑正确口令全流程，429 序列放最后**——30s 锁只影响登录端点）：
+      - `curl -s http://127.0.0.1:3081/auth/login | grep -o 'name="username"'` → 命中；状态 200；
+      - `curl -s -o /dev/null -w "%{http_code}\n" -d "username=admin&password=wrong" http://127.0.0.1:3081/auth/login` → 401；
+      - `curl -s -i -d "username=admin&password=<test-password>" -c jar http://127.0.0.1:3081/auth/login | head -3` → 302 + `set-cookie`；
+      - `curl -s -o /dev/null -w "%{http_code}\n" -b jar http://127.0.0.1:3081/__auth_probe` → 200；
+        无 cookie：`-H "Accept: application/json"` → 401、`-H "Accept: text/html"` → 302；
+      - Bearer 会话 token：`TOK=$(awk '$6=="dsh_auth" {print $7}' jar)` →
+        `curl -s -o /dev/null -w "%{http_code}\n" -H "Authorization: Bearer $TOK" http://127.0.0.1:3081/__auth_probe` → 200；改错 token → 401；
+      - `curl -s http://127.0.0.1:3081/auth/status -b jar` → `{"authenticated":true}`；
+      - WS：无 cookie upgrade → 首行 `HTTP/1.1 401`；`-b jar` → `HTTP/1.1 101`（handoff §5.4 的
+        curl 命令 + `-b jar` / `-H "Authorization: Bearer $TOK"` 变体）；
+      - `curl -s -i -X POST "http://127.0.0.1:3081/auth/logout?next=/" -b jar | head -3` → 302 +
+        `Max-Age=0`；原 cookie 再 `GET /__auth_probe` → 401；
+      - `curl -s -o /dev/null -w "%{http_code}\n" http://127.0.0.1:3081/auth/whatever` → 404；
+      - 最后：错口令连发 6 次（`for i in 1 2 3 4 5 6; do curl -s -o /dev/null -w "%{http_code}\n" -d "username=admin&password=wrong" http://127.0.0.1:3081/auth/login; done`）
+        → 前 5 次 401、第 6 次 429；`curl -s -i -d "username=admin&password=<test-password>" http://127.0.0.1:3081/auth/login | head -5` → 429 + `retry-after` 头。
+   5. 收尾：杀掉实例或留用（报告状态）；`boot.log` 无 `password flow requires M3` 类报错。
+5. 报告：改动文件、P1–P26 落点、覆盖率数字、与本文档的偏差（应为零）。
+6. **写 `docs/handoff-m3_zh.md`**（为 M4 交接）：环境事实增量（如 scrypt 实测耗时、CLI 在服务器上的
+   实际路径）、M3 冒烟真实结果、M3 踩坑清单、M4（TOTP）起点提示。已获用户指令才 commit/push。
+
+---
+
+## 8. 禁区清单
+
+- **不探索 harness 内部**（同 M1/M2）；users 文件、scrypt、yaml 全部只经 §3 的事实。
+- **依赖只加 `yaml`**：scrypt/CLI 参数解析/readline 全内建；devDependencies 不动；不动
+  `dsh-credentials-local` 等任何 harness 包。
+- **不动 token 模式行为**：`token-gate.ts`/`cookie.ts`/`form-body.ts`/`guard.ts`/`gate.ts`/
+  `session-store.ts`/`self-check.ts` 零改动；`auth-endpoints.ts` 仅 P17 一处 import 机械改动；
+  `integration.auth.test.ts` 必须原样绿。
+- **不弱化安全参数**：scrypt N/r/p/maxmem 冻结（P1）；测试不得换弱参数（P25）；限速常量不配置化
+  （P22）。
+- **不落敏感值**：口令/用户名（登录日志）/哈希/会话 token 永不进日志与测试快照（P23）；DUMMY
+  常量例外（非秘密）。
+- **不吞认证失败**：未知用户/错口令/禁用统一 401；文件不可用 503；凭证/文件错误不静默放行。
+- **不改门禁**：eslint/tsconfig/vitest/coverage 阈值不动；不加 eslint-disable（除文件内既有允许项）。
+- **分支纪律**：`development`；未获指令不 commit/push；`lib/` 与 `src/` 同批。
+- M4（TOTP 两段式、`revokeBySubject`、CSRF token、限速持久化）**不做**——需要时只写
+  `TODO(auth-m4):` 注释（带稳定 tag）。
+
+---
+
+## 9. 明确不做（M3 范围外）
+
+- TOTP 两段式登录、`totpSecret` 的使用、防重放（M4）。
+- 禁用用户即时吊销已发会话（P15 局限，M4 评估 `revokeBySubject`）。
+- token + password 双模式并存（mode 二选一，P11）。
+- 登录限速持久化/跨进程（内存态，P10）。
+- CSRF token（P21 评估结论：M3 不加，M4 再评估）。
+- 登录页美化/国际化、client 半边登出按钮（GUI 组件）。
+- 部署侧交付物：正式生产 `cordis.patch.yml`、部署验收清单（M3 冒烟通过后单独做，handoff §6）。

--- a/docs/reverse-proxy_zh.md
+++ b/docs/reverse-proxy_zh.md
@@ -4,7 +4,7 @@
 2026-08-15 生产环境的实测经验：可用的 Caddy 配置、设置页 `403` 背后的浏览器信任栅栏
 坑、以及推荐的「半外壳」拓扑。
 
-> 配套文档：`docs/deployment.md`（中文运维清单与验收步骤）、`docs/dsh-auth-plan.md` §9
+> 配套文档：`docs/deployment_zh.md`（中文运维清单与验收步骤）、`docs/dsh-auth-plan_zh.md` §9
 > M5（规划中的独立外壳）。
 
 ## 1. 为什么必须走反代
@@ -37,11 +37,11 @@ dsh 0.1.0-rc.6 的 `/api` 有浏览器信任栅栏（防 DNS rebinding + CSRF）
 
 ## 3. 拓扑选项
 
-| 选项                       | 认证                         | Host/Origin 重写     | 设置页             | 说明                                      |
-| -------------------------- | ---------------------------- | -------------------- | ------------------ | ----------------------------------------- |
-| 普通反代（Caddy 原样透传） | dsh-auth-gate                | 否                   | privileged API 403 | 除设置页外都正常                          |
-| **半外壳（推荐）**         | dsh-auth-gate                | **是**（Caddy 两行） | **全功能**         | 登录页/限速/吊销全保留                    |
-| 独立外壳（M5，路线图）     | dsh-auth-gate 自身做代理进程 | 内置                 | 全功能             | dsh 零插件；见 `docs/dsh-auth-plan.md` §9 |
+| 选项                       | 认证                         | Host/Origin 重写     | 设置页             | 说明                                         |
+| -------------------------- | ---------------------------- | -------------------- | ------------------ | -------------------------------------------- |
+| 普通反代（Caddy 原样透传） | dsh-auth-gate                | 否                   | privileged API 403 | 除设置页外都正常                             |
+| **半外壳（推荐）**         | dsh-auth-gate                | **是**（Caddy 两行） | **全功能**         | 登录页/限速/吊销全保留                       |
+| 独立外壳（M5，路线图）     | dsh-auth-gate 自身做代理进程 | 内置                 | 全功能             | dsh 零插件；见 `docs/dsh-auth-plan_zh.md` §9 |
 
 重写架空栅栏由门卫补偿：会话 cookie 为 `SameSite=Lax`，跨站/DNS rebinding 请求拿不到
 cookie → 门卫 401。纵深防御从「栅栏 + 门卫」变为「门卫 + SameSite」。
@@ -101,7 +101,7 @@ curl -s -o /dev/null -w "%{http_code}\n" -H "Accept: application/json" https://d
 #   /api/events.host WebSocket 升级 → 带 cookie 101，无 cookie 401
 ```
 
-完整验收清单：`docs/deployment.md` §4（A–I）。
+完整验收清单：`docs/deployment_zh.md` §4（A–I）。
 
 ## 6. 故障诊断
 


### PR DESCRIPTION
## 变更内容

- **命名规范**：docs 全部中文文档改名 `*_zh.md`，英文文档用原名。
- **新增 7 份英文翻译**：`deployment` / `dsh-auth-plan` / `handoff-m2` / `handoff-m3` / `impl-m1` / `impl-m2` / `impl-m3`（代码块、命令、表格、决策编号 D1–D16 / M1–M22 / P1–P26 逐字保留）。
- **交叉引用同步**：中文文档互指 `_zh.md`，英文文档互指原名；README（中英）与 `deploy/cordis.patch.yml` 已更新。
- `docs/development.md` 与 `docs/reverse-proxy.md` 原本即为英文，reverse-proxy 中文版改名 `reverse-proxy_zh.md`。

## 验证

- 7 对文档标题结构逐一配对（`##` 级计数一致）
- 英文文档零残留中文；prettier 全绿