### PR TITLE
docs: merge PRs into main with squash to dedupe release-please changelog

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,6 +38,10 @@ tables).
 
 - Development happens on `development`; `main` only receives merges from
   `development`. CI runs on both branches (push + PR).
+- PRs merge into `main` with **squash** (`gh pr merge <n> --squash`): one
+  conventional commit (the PR title) per PR, so release-please emits one
+  CHANGELOG entry per change. Merge commits double-count (see
+  `docs/development.md` "Releases").
 - Never commit or push to `main` directly unless the user says otherwise —
   always work on `development`.
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -141,6 +141,15 @@ Versioning is fully automated from conventional commits on `main`
   publishes to npm (`dsh-auth-gate`, MIT-licensed); consumers can additionally
   install from git or a local tarball (`npm pack`).
 
+**Merge policy.** Feature/PR workflows merge into `main` with **squash** —
+each PR lands as exactly one conventional commit (the PR title):
+`gh pr merge <n> --squash`. Squash is required, not optional: release-please
+parses the merged branch's commits _and_ (for a merge commit) the merge
+commit's linked PR title, so a merge-commit merge records every change twice
+in the CHANGELOG — the 0.6.0–0.6.4 notes each show the same `client:`/`fix:`
+change under two SHAs (branch commit + merge commit). With squash there is no
+merge commit and each PR contributes exactly one changelog entry.
+
 `docs:`/`chore:`/`ci:`/`test:` commits do not trigger a release. 0.x
 semantics: `fix:` → 0.0.x, `feat:` → 0.x.0.
 


### PR DESCRIPTION
## Problem

The published release notes duplicate every change. For example in v0.6.4:

```
Bug Fixes
client: use theme hover token for sign-out background (dd01e11)
client: use theme hover token for sign-out background (088119f)
```

One entry carries the PR's **merge commit** SHA (`dd01e11`), the other the actual fix commit (`088119f`). The same double listing appears in 0.6.0–0.6.3: every merge-commit-merged change appears twice (branch commit + merge commit). This is because release-please parses the merged branch's conventional commits *and*, for a merge commit, the merge commit's linked PR title.

## Solution

Adopt **squash merging** as the repo convention: each PR lands on `main` as exactly one conventional commit (the PR title), so release-please emits exactly one changelog entry per change and there is no merge commit left to double-count. This is the release-please maintainers' recommended strategy.

## Changes (docs-only, no release)

- `docs/development.md` — add a **Merge policy** note under Releases: merge PRs with `gh pr merge <n> --squash`, explaining why merge commits double-count.
- `AGENTS.md` — mirror the squash convention in the branch-model rules so agents follow it.

A `docs:` commit does not trigger release-please, so this PR is safe to merge without producing a release.
